### PR TITLE
Add Gemini 2.0 Flash Image Generation support

### DIFF
--- a/gemini_manifold.py
+++ b/gemini_manifold.py
@@ -487,6 +487,10 @@ class Pipe:
         else:
             config_params["response_modalities"] = ["Text"]
 
+        # Image Generation model does not support the system prompt message
+        if "gemini-2.0-flash-exp-image-generation" in model_name:
+            del config_params["system_instruction"]
+
         if self.valves.USE_GROUNDING_SEARCH:
             if model_name in ALLOWED_GROUNDING_MODELS:
                 print("[pipe] Using grounding search.")


### PR DESCRIPTION
The `gemini-2.0-flash-exp-image-generation` model does not support the system prompt message, and it should be omitted.

Just a quick fix, hope you'll find it useful.