### PR TITLE
Add valves for base URL, safety settings and lazy model loading

### DIFF
--- a/gemini_manifold.py
+++ b/gemini_manifold.py
@@ -124,6 +124,7 @@ class Pipe:
 
     def __init__(self):
         self.valves = self.Valves()
+        self.last_whitelist = self.valves.MODEL_WHITELIST
         self.models = []
         self.client = None
 
@@ -146,10 +147,16 @@ class Pipe:
             else:
                 log.info("Client already initialized.")
 
-            # Return existing models if already initialized
-            if self.models and self.valves.LAZY_MODEL_FETCHING:
+            # Return existing models if all conditions are met
+            if (
+                self.models
+                and self.valves.LAZY_MODEL_FETCHING
+                and self.last_whitelist == self.valves.MODEL_WHITELIST
+            ):
                 log.info("Models already initialized.")
                 return self.models
+
+            self.last_whitelist = self.valves.MODEL_WHITELIST
 
             # Get and process new models
             models = self._get_google_models()

--- a/gemini_manifold.py
+++ b/gemini_manifold.py
@@ -91,6 +91,10 @@ log = logger.bind(auditable=False)
 class Pipe:
     class Valves(BaseModel):
         GEMINI_API_KEY: str = Field(default="")
+        GEMINI_API_BASE_URL: str = Field(
+            default="https://generativelanguage.googleapis.com",
+            description="The base URL for calling the Gemini API",
+        )
         MODEL_WHITELIST: str = Field(
             default="",
             description="Comma-separated list of allowed model names. Supports wildcards (*).",
@@ -131,8 +135,10 @@ class Pipe:
             # GEMINI_API_KEY is not available inside __init__ for whatever reason so we initialize the client here.
             # TODO Allow user to choose if they want to fetch models only during function initialization or every time pipes is called.
             if not self.client:
+                http_options = types.HttpOptions(base_url=self.valves.GEMINI_API_BASE_URL)
                 self.client = genai.Client(
                     api_key=self.valves.GEMINI_API_KEY,
+                    http_options=http_options,
                 )
             else:
                 log.info("Client already initialized.")

--- a/gemini_manifold.py
+++ b/gemini_manifold.py
@@ -592,7 +592,7 @@ class Pipe:
 
         try:
             whitelist = (
-                self.valves.MODEL_WHITELIST.split(",")
+                self.valves.MODEL_WHITELIST.replace(" ", "").split(",")
                 if self.valves.MODEL_WHITELIST
                 else ["*"]
             )

--- a/gemini_manifold.py
+++ b/gemini_manifold.py
@@ -99,6 +99,10 @@ class Pipe:
             default="",
             description="Comma-separated list of allowed model names. Supports wildcards (*).",
         )
+        LAZY_MODEL_FETCHING: bool = Field(
+            default=True,
+            description="Whether to fetch models only once and reuse them. If False, models will be fetched every time model list is requested.",
+        )
         USE_GROUNDING_SEARCH: bool = Field(
             default=False,
             description="Whether to use Grounding with Google Search. For more info: https://ai.google.dev/gemini-api/docs/grounding",
@@ -133,7 +137,6 @@ class Pipe:
                 raise ValueError("GEMINI_API_KEY is not set.")
 
             # GEMINI_API_KEY is not available inside __init__ for whatever reason so we initialize the client here.
-            # TODO Allow user to choose if they want to fetch models only during function initialization or every time pipes is called.
             if not self.client:
                 http_options = types.HttpOptions(base_url=self.valves.GEMINI_API_BASE_URL)
                 self.client = genai.Client(
@@ -144,7 +147,7 @@ class Pipe:
                 log.info("Client already initialized.")
 
             # Return existing models if already initialized
-            if self.models:
+            if self.models and self.valves.LAZY_MODEL_FETCHING:
                 log.info("Models already initialized.")
                 return self.models
 

--- a/gemini_manifold.py
+++ b/gemini_manifold.py
@@ -99,9 +99,9 @@ class Pipe:
             default="",
             description="Comma-separated list of allowed model names. Supports wildcards (*).",
         )
-        LAZY_MODEL_FETCHING: bool = Field(
+        CACHE_MODELS: bool = Field(
             default=True,
-            description="Whether to fetch models only once and reuse them. If False, models will be fetched every time model list is requested.",
+            description="Whether to request models only on first load and when whitelist changes.",
         )
         USE_GROUNDING_SEARCH: bool = Field(
             default=False,
@@ -153,7 +153,7 @@ class Pipe:
             # Return existing models if all conditions are met
             if (
                 self.models
-                and self.valves.LAZY_MODEL_FETCHING
+                and self.valves.CACHE_MODELS
                 and self.last_whitelist == self.valves.MODEL_WHITELIST
             ):
                 log.info("Models already initialized.")


### PR DESCRIPTION
Added a few more valves and a couple fixes/improvements:
- Added GEMINI_API_BASE_URL for overriding API URL
- Added CACHE_MODELS for toggling cache usage
- Added USE_PERMISSIVE_SAFETY for requesting relaxed safety filters. Different models support different settings, so I used info from SillyTavern
- Models list is reloaded on whitelist change
- Whitelist ignores spaces (so that ", " is a valid separator)

I've been using version 1.3.0 with these changes for a few days with various 2.0 models and tested this rebased version with 2.0 Flash. 