### PR TITLE
Add Gemini 2.0 Pro Exp to the list of grounding models

### DIFF
--- a/gemini_manifold_companion.py
+++ b/gemini_manifold_companion.py
@@ -18,6 +18,8 @@ from pydantic import BaseModel, Field
 # according to https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/ground-gemini
 ALLOWED_GROUNDING_MODELS = [
     "gemini-2.5-pro-exp-03-25",
+    "gemini-2.0-pro-exp-02-05",
+    "gemini-2.0-pro-exp",
     "gemini-2.0-flash",
     "gemini-2.0-flash-exp",
     "gemini-2.0-flash-001",


### PR DESCRIPTION
One more micro-addition from me:

Gemini 2.0 Pro supports grounding as well. Despite being shadowed by 2.5 Pro, I still use and like it for faster time-to-first-token (because of no reasoning stage, I suppose).

## Pull Request Checklist (Gemini Manifold)

- [+] Streaming response
  - [+] LLM responds to user input.
  - [+] LLM processes image inputs (history/prompt).
  - [+] LLM generates images from prompts.
  - [+] LLM uses search; citations displayed.
- [+] Non-streaming resposne
  - [+] LLM responds to user input.
  - [+] LLM processes image inputs (history/prompt).
  - [+] LLM generates images from prompts.
  - [+] LLM uses search; citations displayed.
- [+] Tests pass; code style consistent.
