### PR TITLE
Add support for custom (Workspace) models in Gemini Manifold Companion

### DIFF
--- a/gemini_manifold_companion.py
+++ b/gemini_manifold_companion.py
@@ -52,6 +52,15 @@ class Filter:
 
         # Exit early if we are filtering an unsupported model.
         model_name: str = body.get("model", "")
+
+        # Extract and use base model name in case of custom Workspace models
+        metadata = body.get("metadata", {})
+        base_model_name = (
+            metadata.get("model", {}).get("info", {}).get("base_model_id", None)
+        )
+        if base_model_name:
+            model_name = base_model_name
+        
         if (
             "gemini_manifold_google_genai." not in model_name
             or model_name.replace("gemini_manifold_google_genai.", "")


### PR DESCRIPTION
When the user creates a custom model via Workspace > Models, we should watch for the Base model name instead of the custom model name itself.

**Use-case:**
Personally, I have no custom prompts for plain (base) Gemini or Sonnet models. Instead, I created several custom Workspace models, and they do have custom prompts and other custom parameters. 

Each workspace model has some Base model under the hood.

The pull request tries to fetch the base model name, and if there is one, uses it instead. 

## Pull Request Checklist (Gemini Manifold)

- [+] Streaming response
  - [+] LLM responds to user input.
  - [+] LLM processes image inputs (history/prompt).
  - [+] LLM generates images from prompts.
  - [+] LLM uses search; citations displayed.
- [+] Non-streaming resposne
  - [+] LLM responds to user input.
  - [+] LLM processes image inputs (history/prompt).
  - [+] LLM generates images from prompts.
  - [+] LLM uses search; citations displayed.
- [+] Tests pass; code style consistent.
