### PR TITLE
Add "Thinking budget" valve to restrict or fully disable thinking on Gemini 2.5 models

### DIFF
--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -102,6 +102,10 @@ class Pipe:
         USE_PERMISSIVE_SAFETY: bool = Field(
             default=False, description="Whether to request relaxed safety filtering"
         )
+        THINKING_BUDGET: int = Field(
+            default=24576,
+            description="The maximum number of tokens the model can use to think. Set to 0 to disable thinking.",
+        )
         LOG_LEVEL: Literal["TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = (
             Field(
                 default="INFO",
@@ -206,6 +210,11 @@ class Pipe:
             stop_sequences=body.get("stop"),
             safety_settings=self._get_safety_settings(model_name),
         )
+
+        if "gemini-2.5" in model_name:
+            gen_content_conf.thinking_config = types.ThinkingConfig(
+                thinking_budget=self.valves.THINKING_BUDGET
+            )
 
         gen_content_conf.response_modalities = ["Text"]
         if (

--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -6,7 +6,7 @@ author: suurt8ll
 author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions
 license: MIT
-version: 1.15.0
+version: 1.16.0
 requirements: google-genai==1.11.0
 """
 
@@ -23,6 +23,7 @@ requirements: google-genai==1.11.0
 #   - Each user can decide to use their own API key.
 #   - Token usage data
 #   - Code execution tool. (Gemini Manifold Companion >= 1.1.0 required)
+#   - Set thinking budget for Gemini 2.5 models
 
 # Features that are supported by API but not yet implemented in the manifold:
 #   TODO Audio input support.


### PR DESCRIPTION
Bad news: Gemini 2.5 Flash is thinking by default, so it responds slower.
Good news: one can control thinking budget, even set it to 0 to completely disable thinking.

## Pull Request Checklist (Gemini Manifold)

- [x] Streaming response
  - [x] LLM responds to user input.
  - [x] LLM processes image inputs (history/prompt).
  - [x] LLM generates images from prompts.
  - [x] LLM uses search; citations displayed.
- [x] Non-streaming resposne
  - [x] LLM responds to user input.
  - [x] LLM processes image inputs (history/prompt).
  - [x] LLM generates images from prompts.
  - [x] LLM uses search; citations displayed.
- [x] Tests pass; code style consistent.
