### PR TITLE
feat(gemini): emit a status message while "thinking".

### DIFF
--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -124,6 +124,7 @@ class Pipe:
         EMIT_STATUS_UPDATES: bool = Field(
             default=False,
             description="Whether to emit status updates during model thinking.",
+        )
         LOG_LEVEL: Literal["TRACE", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = (
             Field(
                 default="INFO",


### PR DESCRIPTION
This adds a timer as described in issue below:
resolves #79
The purpose is to make the waiting time less annoying.

# Screenshots

<img width="466" alt="Screenshot 2025-04-18 at 17 23 25" src="https://github.com/user-attachments/assets/0e8bb42a-311e-4974-bd5e-b3a636699c13" />


There are 3 new valves:

<img width="448" alt="Screenshot 2025-04-18 at 17 17 22" src="https://github.com/user-attachments/assets/d27d4893-8f2b-4efd-b3fa-9d6e9c0f77da" />


## Pull Request Checklist (Gemini Manifold)

- [x] Streaming response
  - [x] LLM responds to user input.
  - [x] LLM processes image inputs (history/prompt).
  - [ ] LLM generates images from prompts. -- unable to test, I cannot find a model which generates images
  - [x] LLM uses search; citations displayed. -- unable to test, 2.5 pro doesn't seem to trigger the companion
- [x] Non-streaming resposne
  - [x] LLM responds to user input.
  - [x] LLM processes image inputs (history/prompt).
  - [ ] LLM generates images from prompts. -- unable to test, I cannot find a model which generates images
  - [x] LLM uses search; citations displayed. -- usable to test, I cannot find a model which uses search
- [x] Tests pass; code style consistent.
