### PR TITLE
Simplify caching logic by using `@functool.cache`

### DIFF
--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -212,7 +212,11 @@ class Pipe:
                 {
                     "id": "google/gemini-2.5-flash-preview-04-17",
                     "name": "Gemini 2.5 Flash Preview 04-17",
-                }
+                },
+                {
+                    "id": "google/gemini-2.5-pro-preview-05-06",
+                    "name": "Gemini 2.5 Pro Preview 05-06",
+                },
             ]
 
         # Clear cache if caching is disabled
@@ -407,8 +411,8 @@ class Pipe:
     @cache
     def _get_or_create_genai_client(
         self,
-        api_key: str,
-        base_url: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
         use_vertex_ai: bool | None = None,
         vertex_project: str | None = None,
         vertex_location: str | None = None,

--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -200,6 +200,8 @@ class Pipe:
         """Register all available Google models."""
         self._add_log_handler(self.valves.LOG_LEVEL)
 
+        # FIXME: Hardcoded Gemini flagship models here
+        # while https://github.com/googleapis/python-genai/issues/679 is resolved.
         if self.valves.USE_VERTEX_AI:
             return [
                 {

--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -7,7 +7,7 @@ author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions
 license: MIT
 version: 1.18.2
-requirements: google-genai==1.15.0
+requirements: google-genai==1.15.0, async-lru
 """
 
 # This is a helper function that provides a manifold for Google's Gemini Studio API.
@@ -39,6 +39,7 @@ import copy
 import json
 import time
 from functools import cache
+from async_lru import alru_cache
 from fastapi.datastructures import State
 import io
 import mimetypes
@@ -428,7 +429,7 @@ class Pipe:
             "description": error_msg,
         }
 
-    @cache
+    @alru_cache(maxsize=None)
     async def _get_genai_models(
         self,
         api_key: str | None,

--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -6,7 +6,7 @@ author: suurt8ll
 author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions
 license: MIT
-version: 1.18.0rc1
+version: 1.18.0
 requirements: google-genai==1.13.0
 """
 

--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -164,13 +164,13 @@ class Pipe:
             description="The Google Cloud project ID to use with Vertex AI.",
         )
         VERTEX_LOCATION: str = Field(
-            default="us-central1",
+            default="global",
             description="The Google Cloud region to use with Vertex AI.",
         )
         THINKING_BUDGET: int | None = Field(
             default=None,  # ge / le constraints error for None default, thus are moved to a separate validator
             description="""Gemini 2.5 Flash only. Indicates the thinking budget in tokens.
-            0 means no thinking. Default value is 8192.
+            0 means no thinking. Default value is None (uses the default from Valves).
             See <https://cloud.google.com/vertex-ai/generative-ai/docs/thinking> for more.""",
         )
 
@@ -466,16 +466,14 @@ class Pipe:
             self.valves.VERTEX_LOCATION,
         )
         if user_provides_own_key:
-            log.debug(f"Using user-specific API key for user {__user__.get('email')}.")
+            log.debug(f"Using user API key(s) for user {__user__.get('email')}.")
             api_key = user_valves.GEMINI_API_KEY
             base_url = user_valves.GEMINI_API_BASE_URL
             use_vertex_ai = user_valves.USE_VERTEX_AI
             vertex_project = user_valves.VERTEX_PROJECT
             vertex_location = user_valves.VERTEX_LOCATION
         else:
-            log.debug(
-                f"User {__user__.get('email')} has not provided an API key, using default."
-            )
+            log.debug(f"No API key(s) for user {__user__.get('email')}. Using default.")
 
         client = self._get_or_create_genai_client(
             api_key,
@@ -486,7 +484,7 @@ class Pipe:
         )
 
         if not client:
-            error_msg = "Failed to initialize genai.Client. Check logs for details."
+            error_msg = "Failed to initialize genai client. Check logs for details."
             raise ValueError(error_msg)
 
         return client


### PR DESCRIPTION
This PR uses `@functool.cache` to simplify the caching logic, and remove the need to compare 'old' with 'new' values in a few places:

- to set `log_level`
- to get the genai client with `_get_or_create_genai_client` and `_get_user_client`
- to get the list of models with `_get_genai_models`. the `_filter_models` function is merged into it for simplicity as it was only used just after `_get_genai_models`