### PR TITLE
feat(gemini): URL Context Tool

### DIFF
--- a/docs/plugins/pipes/gemini_manifold.md
+++ b/docs/plugins/pipes/gemini_manifold.md
@@ -24,6 +24,7 @@ Here's a breakdown of implemented and planned features for the Gemini Manifold p
 -   [x] White- and blacklist based model retrieval and registration.
 -   [x] Display usage statistics (token counts)
 -   [x] Code execution tool. ("Gemini Manifold Companion" >= 1.1.0 required)
+-   [x] URL context tool (allows the model to fetch and use content from provided URLs for grounding). (Gemini Manifold Companion not required for this specific tool, but model compatibility is necessary).
 
 **Planned Features:**
 
@@ -37,6 +38,40 @@ To install this plugin, navigate to the [Open WebUI Community page for Gemini Ma
 ## Configuration
 
 After installation, click the gear icon next to the `gemini_manifold_google_genai` function within Open WebUI. At a minimum, you must enter your Google Gemini API key. Other configurable options are also available on that settings page.
+
+## URL Context Tool
+
+The URL Context Tool enhances Gemini's capabilities by allowing it to fetch and incorporate content from web pages directly into its context when generating responses. This is useful for grounding answers with specific, up-to-date information from the web.
+
+**Enabling the Tool:**
+
+To use this feature, you need to enable it via the `ENABLE_URL_CONTEXT_TOOL` valve in the `Pipe.Valves` configuration. Set this valve to `True`. By default, it is `False`.
+
+```python
+class Pipe:
+    class Valves(BaseModel):
+        # ... other valves
+        ENABLE_URL_CONTEXT_TOOL: bool = Field(
+            default=False,
+            description="Enable the URL context tool to allow the model to fetch and use content from provided URLs. This tool is only compatible with specific models.",
+        )
+        # ... other valves
+```
+
+**Supported Models:**
+
+This tool is only available for the following models:
+*   `gemini-2.5-pro-preview-05-06`
+*   `gemini-2.5-flash-preview-05-20`
+*   `gemini-2.0-flash`
+*   `gemini-2.0-flash-live-001`
+
+If the tool is enabled but an unsupported model is selected, it will be automatically skipped.
+
+**Important Notes:**
+
+*   This tool is intended for general URLs provided in your prompt. It is separate from the automatic handling of YouTube URLs (from `youtube.com` or `youtu.be`), which are processed differently by the manifold.
+*   When the tool successfully retrieves content from URLs, these URLs will be listed in the chat interface, providing transparency about the information sources used by the model. (This requires front-end support for the `chat:url_context` event).
 
 ## Usage
 

--- a/tests/test_gemini_manifold.py
+++ b/tests/test_gemini_manifold.py
@@ -29,6 +29,13 @@ from plugins.pipes.gemini_manifold import (
     Pipe,
     types as gemini_types,
 )  # gemini_types is google.genai.types
+from unittest.mock import ANY
+
+
+# Helper async generator for mocking streaming responses
+async def async_iter(items):
+    for item in items:
+        yield item
 
 
 @pytest.fixture
@@ -46,6 +53,7 @@ def mock_pipe_valves_data():
         "EMIT_INTERVAL": 1,
         "EMIT_STATUS_UPDATES": False,
         "LOG_LEVEL": "INFO",
+        "ENABLE_URL_CONTEXT_TOOL": False,  # Default to False for most existing tests
     }
 
 
@@ -53,10 +61,20 @@ def mock_pipe_valves_data():
 # This reduces boilerplate in each test function.
 @pytest.fixture
 def pipe_instance_fixture(mock_pipe_valves_data):
+    # Create a fresh copy of valves_data for each test to avoid modification pollution
+    current_test_valves_data = mock_pipe_valves_data.copy()
+
     mock_gemini_client_instance = MagicMock()
-    mock_functions_module.Functions.get_function_valves_by_id.reset_mock()  # Reset for independence
+    # Configure the client instance to have the 'aio.models' attribute structure
+    mock_gemini_client_instance.aio = MagicMock()
+    mock_gemini_client_instance.aio.models = MagicMock()
+    mock_gemini_client_instance.aio.models.generate_content_stream = AsyncMock()
+    mock_gemini_client_instance.aio.models.generate_content = AsyncMock()
+
+    # Reset mocks that might be called during Pipe instantiation or setup
+    mock_functions_module.Functions.get_function_valves_by_id.reset_mock()
     mock_functions_module.Functions.get_function_valves_by_id.return_value = (
-        mock_pipe_valves_data
+        current_test_valves_data
     )
 
     with patch(
@@ -68,21 +86,26 @@ def pipe_instance_fixture(mock_pipe_valves_data):
         "sys.stdout", MagicMock()  # Suppress print/log output during setup
     ):
         pipe = Pipe()
-        # Basic verification that Pipe initialized successfully
-        mock_functions_module.Functions.get_function_valves_by_id.assert_called_once()
-        MockedGenAIClientConstructor.assert_called_once()
-        mock_internal_add_log_handler.assert_called_once()
-        yield pipe  # Use yield to make it a fixture that provides the instance
+        # Yield a dictionary containing the pipe instance and the mock client
+        # This allows tests to access the mock client directly if needed
+        yield {
+            "pipe": pipe,
+            "mock_client": mock_gemini_client_instance,
+            "mock_valves_data": current_test_valves_data,
+            "MockedGenAIClientConstructor": MockedGenAIClientConstructor,
+            "mock_internal_add_log_handler": mock_internal_add_log_handler,
+        }
 
 
 def test_pipe_initialization_with_api_key(mock_pipe_valves_data):
-    # This test now uses a more focused setup for Pipe instantiation if needed,
-    # or can be simplified if pipe_instance_fixture covers its needs.
-    # For this specific test, let's keep its original detailed setup to show the direct interactions.
+    # This test is about the initialization process itself.
+    # We use the raw mock_pipe_valves_data here.
+    valves_data_for_this_test = mock_pipe_valves_data.copy()
+
     mock_gemini_client_instance = MagicMock()
     mock_functions_module.Functions.get_function_valves_by_id.reset_mock()
     mock_functions_module.Functions.get_function_valves_by_id.return_value = (
-        mock_pipe_valves_data
+        valves_data_for_this_test
     )
 
     with patch(
@@ -93,26 +116,82 @@ def test_pipe_initialization_with_api_key(mock_pipe_valves_data):
     ) as mock_internal_add_log_handler, patch(
         "sys.stdout", MagicMock()
     ):
-        pipe_instance = Pipe()
+        # We need to re-initialize Pipe.valves for this specific test context
+        # as pipe_instance_fixture might have already set it up with its own copy
+        pipe_instance_valves = Pipe.Valves(**valves_data_for_this_test)
+        
+        # Temporarily patch self.valves for the _get_or_create_genai_client call
+        # within the Pipe constructor if it's called there.
+        # More robustly, ensure the fixture provides a fresh Pipe instance for each test.
+        # The fixture approach is better. This test can use the fixture and assert on its state.
 
+        # Re-instantiate Pipe to test its __init__ logic directly
+        # Note: The fixture `pipe_instance_fixture` also creates a Pipe instance.
+        # If this test is solely about __init__, it should manage its own Pipe creation
+        # or rely on the fixture and assert post-conditions.
+        # Let's use a fresh instance for clarity on __init__ testing.
+        
+        pipe_instance = Pipe() # This will use the mocked get_function_valves_by_id
+
+        # Assertions
         mock_functions_module.Functions.get_function_valves_by_id.assert_called_once_with(
             "gemini_manifold_google_genai"
         )
         assert isinstance(pipe_instance.valves, Pipe.Valves)
-        assert pipe_instance.valves.GEMINI_API_KEY == "test_default_api_key_from_valves"
-        mock_internal_add_log_handler.assert_called_once()
-        MockedGenAIClientConstructor.assert_called_once_with(
-            api_key="test_default_api_key_from_valves",
+        assert pipe_instance.valves.GEMINI_API_KEY == valves_data_for_this_test["GEMINI_API_KEY"]
+        
+        # _add_log_handler is called in pipes() and pipe() methods, not __init__ usually.
+        # If it's called by _get_or_create_genai_client or similar during __init__, this is fine.
+        # Based on current code, _get_or_create_genai_client is NOT called in __init__.
+        # It's called in _get_user_client, which is called in pipe(), or in _get_genai_models (in pipes()).
+        # So, mock_internal_add_log_handler.assert_called_once() might be too strict if __init__ doesn't log.
+        # Let's assume the fixture handles the default client creation path which might log.
+        # The fixture already asserts these, so this test can focus on values.
+
+        # The client is created on first access via _get_user_client or _get_genai_models.
+        # The fixture creates a default client. Let's verify the arguments if it was created.
+        # If the fixture is used, it handles this. If Pipe() is called directly, client isn't made yet.
+        # For this specific test, let's assume we want to check the first client creation.
+        # We can trigger it by calling a method that uses the client.
+        # However, the prompt is about Pipe initialization.
+        # The fixture `pipe_instance_fixture` already tests the client creation part.
+        # This test should focus on the state of `pipe_instance.valves`.
+        # The MockedGenAIClientConstructor assertion belongs more to the fixture setup verification.
+        
+        # If the goal is to test the client creation path triggered by __init__ (if any),
+        # then the mock setup needs to align with that.
+        # Current Pipe.__init__ just sets self.valves.
+        # The client is lazy-loaded or pre-warmed by the fixture.
+        # Let's ensure this test is meaningful for __init__ specifically.
+        
+        # If the client *is* created by __init__ (e.g., self.clients["default"] = ... in __init__)
+        # then MockedGenAIClientConstructor.assert_called_once_with(...) is correct.
+        # Based on the provided code, `self.clients` is not a thing, client is created on demand.
+        # The fixture warms up a client by calling _get_or_create_genai_client
+        # Let's rely on the fixture for client creation tests and keep this focused.
+
+        # This test can be simplified if pipe_instance_fixture is used and assertions are made on its state.
+        # Let's use the fixture provided state to assert.
+        
+        setup = pipe_instance_fixture # This re-runs the fixture for this test
+        
+        setup["MockedGenAIClientConstructor"].assert_called_once_with(
+            api_key=valves_data_for_this_test["GEMINI_API_KEY"],
             http_options=gemini_types.HttpOptions(
-                base_url="https://test.googleapis.com"
+                base_url=valves_data_for_this_test["GEMINI_API_BASE_URL"]
             ),
+            vertexai=ANY, # Added due to changes in _get_or_create_genai_client
+            project=ANY,
+            location=ANY,
         )
-        assert pipe_instance.clients["default"] == mock_gemini_client_instance
+        assert setup["pipe"].valves.GEMINI_API_KEY == valves_data_for_this_test["GEMINI_API_KEY"]
+        setup["mock_internal_add_log_handler"].assert_called_once() # From fixture setup
 
 
 @pytest.mark.asyncio
 async def test_genai_contents_from_messages_simple_user_text(pipe_instance_fixture):
-    pipe_instance = pipe_instance_fixture  # Get the pre-configured pipe instance
+    pipe_details = pipe_instance_fixture
+    pipe_instance = pipe_details["pipe"]
 
     messages_body = [{"role": "user", "content": "Hello!"}]
     messages_db = None
@@ -144,7 +223,8 @@ async def test_genai_contents_from_messages_simple_user_text(pipe_instance_fixtu
 async def test_genai_contents_from_messages_youtube_link_mixed_with_text(
     pipe_instance_fixture,
 ):
-    pipe_instance = pipe_instance_fixture  # Get the pre-configured pipe instance
+    pipe_details = pipe_instance_fixture
+    pipe_instance = pipe_details["pipe"]
 
     # Arrange: Inputs
     youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
@@ -206,37 +286,21 @@ async def test_genai_contents_from_messages_youtube_link_mixed_with_text(
         content_item = contents[0]
         assert content_item.role == "user", "Content item role should be 'user'"
 
-        # --- Assertions for correct part segmentation and ordering (THESE WILL LIKELY FAIL with current code) ---
-        # This is the core of the test, expecting proper interleaving.
-        # Current code likely produces 2 parts: [YouTubePart, FullTextPart(including URL)]
-
+        # --- Assertions for correct part segmentation and ordering ---
         assert (
             len(content_item.parts) == 3
         ), f"Expected 3 parts (text, youtube, text), but got {len(content_item.parts)}. Parts: {[str(p) for p in content_item.parts]}"
 
         # Verify calls to types.Part.from_text
-        # Expected: two calls, one for text_before_stripped, one for text_after_stripped.
-        # Current code likely calls it once with the full user_content_string.
-        expected_from_text_calls = [
-            call(text=text_before_stripped),
-            call(text=text_after_stripped),
-        ]
-        # Using assert_has_calls because the order of these text parts relative to each other
-        # (if there were multiple text segments from markdown processing) might not be fixed,
-        # but for this simple case, call_args_list would be stricter.
-        # However, given the side_effect, checking the objects in content_item.parts is more direct.
-        # Let's check call_count first, then the actual parts.
         assert (
             mock_part_from_text.call_count == 2
         ), f"Expected Part.from_text to be called 2 times, but was called {mock_part_from_text.call_count} times. Calls: {mock_part_from_text.call_args_list}"
 
         # Assert the content and order of parts
-        # Part 1: Text before the YouTube link
         assert (
             content_item.parts[0] is mock_text_part_before_obj
         ), f"Part 0 was not the expected 'text_before' mock. Got: {content_item.parts[0]}"
 
-        # Part 2: The YouTube link
         youtube_part = content_item.parts[1]
         assert isinstance(
             youtube_part, gemini_types.Part
@@ -250,23 +314,21 @@ async def test_genai_contents_from_messages_youtube_link_mixed_with_text(
         assert (
             youtube_part.file_data.file_uri == youtube_url
         ), f"YouTube part URI mismatch. Expected: {youtube_url}, Got: {youtube_part.file_data.file_uri}"
-        # Ensure it's not accidentally a text part
         assert (
             not hasattr(youtube_part, "text") or youtube_part.text is None
         ), "YouTube part should not have a 'text' attribute or it should be None"
 
-        # Part 3: Text after the YouTube link
         assert (
             content_item.parts[2] is mock_text_part_after_obj
         ), f"Part 2 was not the expected 'text_after' mock. Got: {content_item.parts[2]}"
 
-        # Ensure event_emitter was not called for this simple case
         mock_event_emitter.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_genai_contents_from_messages_user_text_with_pdf(pipe_instance_fixture):
-    pipe_instance = pipe_instance_fixture
+    pipe_details = pipe_instance_fixture
+    pipe_instance = pipe_details["pipe"]
 
     # Arrange: Inputs
     user_text_content = "Please analyze this PDF."
@@ -349,6 +411,267 @@ async def test_genai_contents_from_messages_user_text_with_pdf(pipe_instance_fix
         ), "Second part should be the text mock."
 
         mock_event_emitter.assert_not_called()
+
+
+# --- Tests for URL Context Tool ---
+@pytest.mark.asyncio
+async def test_url_context_tool_enabled_compatible_model(pipe_instance_fixture):
+    pipe_details = pipe_instance_fixture
+    pipe_instance = pipe_details["pipe"]
+    mock_client = pipe_details["mock_client"]
+    pipe_details["mock_valves_data"]["ENABLE_URL_CONTEXT_TOOL"] = True
+
+    body = {
+        "model": "models/gemini-2.5-flash-preview-05-20", # Compatible model
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": True,
+    }
+    user_data = {"id": "test_user_id", "email": "test@example.com", "valves": None}
+    request_mock = MagicMock()
+    event_emitter_mock = AsyncMock()
+    metadata = {"chat_id": "chat123", "message_id": "msg123", "features": {}}
+
+    # Mock the streaming response
+    mock_response_chunk = MagicMock(spec=gemini_types.GenerateContentResponse)
+    mock_candidate = MagicMock(spec=gemini_types.Candidate)
+    mock_candidate.content = gemini_types.Content(parts=[gemini_types.Part(text="response")])
+    mock_candidate.finish_reason = gemini_types.FinishReason.STOP
+    mock_candidate.url_context_metadata = None
+    mock_candidate.grounding_metadata = None # Ensure this is None or a mock
+    mock_response_chunk.candidates = [mock_candidate]
+    mock_response_chunk.usage_metadata = MagicMock()
+    mock_client.aio.models.generate_content_stream.return_value = async_iter([mock_response_chunk])
+
+    # Call the pipe method
+    async for _ in await pipe_instance.pipe(body, user_data, request_mock, event_emitter_mock, metadata):
+        pass
+
+    # Assert generate_content_stream was called
+    mock_client.aio.models.generate_content_stream.assert_called_once()
+    args, kwargs = mock_client.aio.models.generate_content_stream.call_args
+    
+    # Check that UrlContext tool is in the tools list
+    generate_config = kwargs["config"]
+    assert gemini_types.Tool(url_context=gemini_types.UrlContext()) in generate_config.tools
+    
+    # Check that no YouTube FileData part was created
+    contents_passed = kwargs["contents"]
+    for content_item in contents_passed:
+        for part in content_item.parts:
+            assert not (hasattr(part, "file_data") and part.file_data and "youtube.com" in part.file_data.file_uri), \
+                   "YouTube FileData part should not be present without a YouTube URL"
+
+
+@pytest.mark.asyncio
+async def test_url_context_tool_enabled_incompatible_model(pipe_instance_fixture):
+    pipe_details = pipe_instance_fixture
+    pipe_instance = pipe_details["pipe"]
+    mock_client = pipe_details["mock_client"]
+    pipe_details["mock_valves_data"]["ENABLE_URL_CONTEXT_TOOL"] = True
+
+    body = {
+        "model": "models/gemini-1.0-pro",  # Incompatible model
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": True,
+    }
+    # ... (rest of the setup is similar to the compatible model test)
+    user_data = {"id": "test_user_id", "email": "test@example.com", "valves": None}
+    request_mock = MagicMock()
+    event_emitter_mock = AsyncMock()
+    metadata = {"chat_id": "chat123", "message_id": "msg123", "features": {}}
+
+    mock_response_chunk = MagicMock(spec=gemini_types.GenerateContentResponse) # Basic mock
+    mock_candidate = MagicMock(spec=gemini_types.Candidate)
+    mock_candidate.content = gemini_types.Content(parts=[gemini_types.Part(text="response")])
+    mock_candidate.finish_reason = gemini_types.FinishReason.STOP
+    mock_candidate.url_context_metadata = None
+    mock_candidate.grounding_metadata = None
+    mock_response_chunk.candidates = [mock_candidate]
+    mock_response_chunk.usage_metadata = MagicMock()
+    mock_client.aio.models.generate_content_stream.return_value = async_iter([mock_response_chunk])
+
+    async for _ in await pipe_instance.pipe(body, user_data, request_mock, event_emitter_mock, metadata):
+        pass
+        
+    mock_client.aio.models.generate_content_stream.assert_called_once()
+    args, kwargs = mock_client.aio.models.generate_content_stream.call_args
+    generate_config = kwargs["config"]
+    assert gemini_types.Tool(url_context=gemini_types.UrlContext()) not in generate_config.tools
+
+
+@pytest.mark.asyncio
+async def test_url_context_tool_disabled(pipe_instance_fixture):
+    pipe_details = pipe_instance_fixture
+    pipe_instance = pipe_details["pipe"]
+    mock_client = pipe_details["mock_client"]
+    pipe_details["mock_valves_data"]["ENABLE_URL_CONTEXT_TOOL"] = False # Explicitly disabled
+
+    body = {
+        "model": "models/gemini-2.5-flash-preview-05-20", # Compatible model
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": True,
+    }
+    # ... (rest of the setup)
+    user_data = {"id": "test_user_id", "email": "test@example.com", "valves": None}
+    request_mock = MagicMock()
+    event_emitter_mock = AsyncMock()
+    metadata = {"chat_id": "chat123", "message_id": "msg123", "features": {}}
+    
+    mock_response_chunk = MagicMock(spec=gemini_types.GenerateContentResponse) # Basic mock
+    mock_candidate = MagicMock(spec=gemini_types.Candidate)
+    mock_candidate.content = gemini_types.Content(parts=[gemini_types.Part(text="response")])
+    mock_candidate.finish_reason = gemini_types.FinishReason.STOP
+    mock_candidate.url_context_metadata = None
+    mock_candidate.grounding_metadata = None
+    mock_response_chunk.candidates = [mock_candidate]
+    mock_response_chunk.usage_metadata = MagicMock()
+    mock_client.aio.models.generate_content_stream.return_value = async_iter([mock_response_chunk])
+
+    async for _ in await pipe_instance.pipe(body, user_data, request_mock, event_emitter_mock, metadata):
+        pass
+
+    mock_client.aio.models.generate_content_stream.assert_called_once()
+    args, kwargs = mock_client.aio.models.generate_content_stream.call_args
+    generate_config = kwargs["config"]
+    assert gemini_types.Tool(url_context=gemini_types.UrlContext()) not in generate_config.tools
+
+@pytest.mark.asyncio
+async def test_youtube_url_handling_precedence_with_url_context(pipe_instance_fixture):
+    pipe_details = pipe_instance_fixture
+    pipe_instance = pipe_details["pipe"]
+    mock_client = pipe_details["mock_client"]
+    pipe_details["mock_valves_data"]["ENABLE_URL_CONTEXT_TOOL"] = True
+
+    youtube_url = "https://www.youtube.com/watch?v=video123"
+    other_url = "https://example.com/article"
+    message_content = f"Check this YouTube video {youtube_url} and this article {other_url}"
+
+    body = {
+        "model": "models/gemini-2.5-flash-preview-05-20", # Compatible
+        "messages": [{"role": "user", "content": message_content}],
+        "stream": True,
+    }
+    # ... (rest of the setup)
+    user_data = {"id": "test_user_id", "email": "test@example.com", "valves": None}
+    request_mock = MagicMock()
+    event_emitter_mock = AsyncMock()
+    metadata = {"chat_id": "chat123", "message_id": "msg123", "features": {}}
+
+    mock_response_chunk = MagicMock(spec=gemini_types.GenerateContentResponse) # Basic mock
+    mock_candidate = MagicMock(spec=gemini_types.Candidate)
+    mock_candidate.content = gemini_types.Content(parts=[gemini_types.Part(text="response")])
+    mock_candidate.finish_reason = gemini_types.FinishReason.STOP
+    mock_candidate.url_context_metadata = None
+    mock_candidate.grounding_metadata = None
+    mock_response_chunk.candidates = [mock_candidate]
+    mock_response_chunk.usage_metadata = MagicMock()
+    mock_client.aio.models.generate_content_stream.return_value = async_iter([mock_response_chunk])
+    
+    async for _ in await pipe_instance.pipe(body, user_data, request_mock, event_emitter_mock, metadata):
+        pass
+
+    mock_client.aio.models.generate_content_stream.assert_called_once()
+    args, kwargs = mock_client.aio.models.generate_content_stream.call_args
+    
+    # Assert URL Context tool is present
+    generate_config = kwargs["config"]
+    assert gemini_types.Tool(url_context=gemini_types.UrlContext()) in generate_config.tools
+    
+    # Assert YouTube URL is a FileData part
+    contents_passed = kwargs["contents"]
+    found_youtube_file_data = False
+    found_other_url_in_text = False
+
+    for content_item in contents_passed:
+        if content_item.role == "user":
+            for part in content_item.parts:
+                if hasattr(part, "file_data") and part.file_data and part.file_data.file_uri == youtube_url:
+                    found_youtube_file_data = True
+                if hasattr(part, "text") and part.text and other_url in part.text:
+                    found_other_url_in_text = True
+    
+    assert found_youtube_file_data, "YouTube URL should be processed as FileData"
+    assert found_other_url_in_text, "Non-YouTube URL should be part of a text part"
+
+
+@pytest.mark.asyncio
+async def test_url_context_metadata_processing(pipe_instance_fixture):
+    pipe_details = pipe_instance_fixture
+    pipe_instance = pipe_details["pipe"]
+    mock_client = pipe_details["mock_client"]
+    pipe_details["mock_valves_data"]["ENABLE_URL_CONTEXT_TOOL"] = True
+
+    body = {
+        "model": "models/gemini-2.5-pro-preview-05-06", # Compatible
+        "messages": [{"role": "user", "content": "Summarize https://example.com/page1"}],
+        "stream": True,
+    }
+    user_data = {"id": "test_user_id", "email": "test@example.com", "valves": None}
+    request_mock = MagicMock()
+    event_emitter_mock = AsyncMock()
+    metadata = {"chat_id": "chat123", "message_id": "msg123", "features": {}}
+
+    # --- Mock response with URL context metadata ---
+    mock_retrieved_url1 = MagicMock(spec=gemini_types.UrlContextRetrievedUrl)
+    mock_retrieved_url1.url = "https://example.com/retrieved1"
+    mock_retrieved_url1.title = "Retrieved Page 1"
+
+    mock_url_metadata = MagicMock(spec=gemini_types.UrlContextMetadata)
+    mock_url_metadata.retrieved_urls = [mock_retrieved_url1]
+
+    mock_candidate = MagicMock(spec=gemini_types.Candidate)
+    mock_candidate.url_context_metadata = mock_url_metadata
+    mock_candidate.finish_reason = gemini_types.FinishReason.STOP
+    # Ensure content and parts exist, even if minimal
+    mock_part = MagicMock(spec=gemini_types.Part)
+    mock_part.text = "Model response based on URL."
+    mock_content = MagicMock(spec=gemini_types.Content)
+    mock_content.parts = [mock_part]
+    mock_candidate.content = mock_content
+    mock_candidate.grounding_metadata = None # Important for _do_post_processing logic
+
+    mock_final_response_chunk = MagicMock(spec=gemini_types.GenerateContentResponse)
+    mock_final_response_chunk.candidates = [mock_candidate]
+    mock_final_response_chunk.usage_metadata = MagicMock() # For _get_usage_data_event
+    mock_final_response_chunk.usage_metadata.prompt_token_count = 10
+    mock_final_response_chunk.usage_metadata.candidates_token_count = 20
+    mock_final_response_chunk.usage_metadata.total_token_count = 30
+    
+    # Simulate a stream with one chunk that contains all data
+    mock_client.aio.models.generate_content_stream.return_value = async_iter([mock_final_response_chunk])
+
+    # Call the pipe method and consume the stream
+    async for _ in await pipe_instance.pipe(body, user_data, request_mock, event_emitter_mock, metadata):
+        pass
+
+    # Assert event_emitter was called with chat:url_context
+    # event_emitter_mock.assert_any_call(...) doesn't quite work for complex dicts easily.
+    # We need to find the call in call_args_list.
+    
+    emitted_url_context_event = None
+    for call_item in event_emitter_mock.call_args_list:
+        args, _ = call_item
+        event = args[0] # The event is the first positional argument
+        if event.get("type") == "chat:url_context":
+            emitted_url_context_event = event
+            break
+    
+    assert emitted_url_context_event is not None, "chat:url_context event was not emitted"
+    assert emitted_url_context_event["data"]["retrieved_urls"] == [
+        {"url": "https://example.com/retrieved1", "title": "Retrieved Page 1"}
+    ]
+
+    # Also ensure usage data event was called, as it's part of _do_post_processing
+    emitted_usage_event = None
+    for call_item in event_emitter_mock.call_args_list:
+        args, _ = call_item
+        event = args[0]
+        if event.get("type") == "chat:completion" and "usage" in event.get("data", {}):
+            emitted_usage_event = event
+            break
+    assert emitted_usage_event is not None, "chat:completion event with usage data was not emitted"
+
+# --- End of Tests for URL Context Tool ---
 
 
 def teardown_module(module):


### PR DESCRIPTION
I let [Jules](https://jules.google) take a crack at #119. It looks like it was able to implement the feature correctly, the tests it wrote should probably be reviewed though.

AI generated:

This allows compatible Gemini models to fetch and use content from URLs you provide as context for generating responses.

Here are the key changes:
- I added a way to control this feature, which is off by default.
- This new ability is only active for specific supported models:
  - `gemini-2.5-pro-preview-05-06`
  - `gemini-2.5-flash-preview-05-20`
  - `gemini-2.0-flash`
  - `gemini-2.0-flash-live-001`
- I've made sure that my existing way of handling YouTube URLs takes precedence and isn't affected.
- I now process `url_context_metadata` from the model's response and will let the front-end know about any retrieved URLs so they can be displayed to you.
- I've updated the documentation with details on this new feature, how to configure it, and how to use it.
- I've also added comprehensive checks to cover various scenarios, including enabling the feature, model compatibility, YouTube URL precedence, and metadata processing.