### PR TITLE
Fix: Correct test failures in test_gemini_manifold.py

### DIFF
--- a/tests/test_gemini_manifold.py
+++ b/tests/test_gemini_manifold.py
@@ -1,3 +1,5 @@
+from typing import cast
+from aiocache.base import BaseCache
 import pytest
 import pytest_asyncio
 from unittest.mock import (
@@ -55,10 +57,6 @@ def mock_pipe_valves_data():
 @pytest_asyncio.fixture
 async def pipe_instance_fixture(mock_pipe_valves_data):
     mock_gemini_client_instance = MagicMock()
-    # mock_functions_module.Functions.get_function_valves_by_id.reset_mock()  # Removed
-    # mock_functions_module.Functions.get_function_valves_by_id.return_value = (  # Removed
-    #     mock_pipe_valves_data
-    # )
 
     with patch(
         "plugins.pipes.gemini_manifold.genai.Client",
@@ -69,28 +67,18 @@ async def pipe_instance_fixture(mock_pipe_valves_data):
         "sys.stdout", MagicMock()  # Suppress print/log output during setup
     ):
         pipe = Pipe()
-        pipe.valves = Pipe.Valves(**mock_pipe_valves_data)  # Added
-        # Basic verification that Pipe initialized successfully
-        # mock_functions_module.Functions.get_function_valves_by_id.assert_called_once() # Removed
-        # MockedGenAIClientConstructor.assert_called_once() # Removed as per task description
-        # mock_internal_add_log_handler.assert_called_once() # Removed
+        pipe.valves = Pipe.Valves(**mock_pipe_valves_data)
         yield pipe  # Use yield to make it a fixture that provides the instance
 
     # Teardown: Clear caches
     Pipe._get_or_create_genai_client.cache_clear()
-    if hasattr(pipe._get_genai_models, "cache") and pipe._get_genai_models.cache:
-        await pipe._get_genai_models.cache.clear()
+    cache_instance = getattr(pipe._get_genai_models, "cache")
+    if cache_instance:
+        await cast(BaseCache, cache_instance).clear()
 
 
 def test_pipe_initialization_with_api_key(mock_pipe_valves_data):
-    # This test now uses a more focused setup for Pipe instantiation if needed,
-    # or can be simplified if pipe_instance_fixture covers its needs.
-    # For this specific test, let's keep its original detailed setup to show the direct interactions.
     mock_gemini_client_instance = MagicMock()
-    # mock_functions_module.Functions.get_function_valves_by_id.reset_mock() # Removed
-    # mock_functions_module.Functions.get_function_valves_by_id.return_value = ( # Removed
-    #     mock_pipe_valves_data
-    # )
 
     with patch(
         "plugins.pipes.gemini_manifold.genai.Client",
@@ -102,17 +90,18 @@ def test_pipe_initialization_with_api_key(mock_pipe_valves_data):
     ):
         try:
             pipe_instance = Pipe()
-            pipe_instance.valves = Pipe.Valves(**mock_pipe_valves_data) # Added
+            pipe_instance.valves = Pipe.Valves(**mock_pipe_valves_data)  # Added
 
-            # mock_functions_module.Functions.get_function_valves_by_id.assert_called_once_with( # Removed
-            #     "gemini_manifold_google_genai"
-            # )
             assert isinstance(pipe_instance.valves, Pipe.Valves)
-            assert pipe_instance.valves.GEMINI_API_KEY == "test_default_api_key_from_valves"
-            # mock_internal_add_log_handler.assert_called_once() # Removed
+            assert (
+                pipe_instance.valves.GEMINI_API_KEY
+                == "test_default_api_key_from_valves"
+            )
 
             # Trigger client creation
-            pipe_instance._get_user_client(pipe_instance.valves, "test_user_email@example.com")
+            pipe_instance._get_user_client(
+                pipe_instance.valves, "test_user_email@example.com"
+            )
 
             MockedGenAIClientConstructor.assert_called_once_with(
                 api_key="test_default_api_key_from_valves",
@@ -120,7 +109,6 @@ def test_pipe_initialization_with_api_key(mock_pipe_valves_data):
                     base_url="https://test.googleapis.com"
                 ),
             )
-            # assert pipe_instance.clients["default"] == mock_gemini_client_instance # Removed as per instructions
         finally:
             Pipe._get_or_create_genai_client.cache_clear()
 

--- a/tests/test_gemini_manifold.py
+++ b/tests/test_gemini_manifold.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 from unittest.mock import (
     patch,
     MagicMock,
@@ -51,13 +52,13 @@ def mock_pipe_valves_data():
 
 # Helper to setup Pipe instance for tests that need it
 # This reduces boilerplate in each test function.
-@pytest.fixture
-def pipe_instance_fixture(mock_pipe_valves_data):
+@pytest_asyncio.fixture
+async def pipe_instance_fixture(mock_pipe_valves_data):
     mock_gemini_client_instance = MagicMock()
-    mock_functions_module.Functions.get_function_valves_by_id.reset_mock()  # Reset for independence
-    mock_functions_module.Functions.get_function_valves_by_id.return_value = (
-        mock_pipe_valves_data
-    )
+    # mock_functions_module.Functions.get_function_valves_by_id.reset_mock()  # Removed
+    # mock_functions_module.Functions.get_function_valves_by_id.return_value = (  # Removed
+    #     mock_pipe_valves_data
+    # )
 
     with patch(
         "plugins.pipes.gemini_manifold.genai.Client",
@@ -68,11 +69,17 @@ def pipe_instance_fixture(mock_pipe_valves_data):
         "sys.stdout", MagicMock()  # Suppress print/log output during setup
     ):
         pipe = Pipe()
+        pipe.valves = Pipe.Valves(**mock_pipe_valves_data)  # Added
         # Basic verification that Pipe initialized successfully
-        mock_functions_module.Functions.get_function_valves_by_id.assert_called_once()
-        MockedGenAIClientConstructor.assert_called_once()
-        mock_internal_add_log_handler.assert_called_once()
+        # mock_functions_module.Functions.get_function_valves_by_id.assert_called_once() # Removed
+        # MockedGenAIClientConstructor.assert_called_once() # Removed as per task description
+        # mock_internal_add_log_handler.assert_called_once() # Removed
         yield pipe  # Use yield to make it a fixture that provides the instance
+
+    # Teardown: Clear caches
+    Pipe._get_or_create_genai_client.cache_clear()
+    if hasattr(pipe._get_genai_models, "cache") and pipe._get_genai_models.cache:
+        await pipe._get_genai_models.cache.clear()
 
 
 def test_pipe_initialization_with_api_key(mock_pipe_valves_data):
@@ -80,10 +87,10 @@ def test_pipe_initialization_with_api_key(mock_pipe_valves_data):
     # or can be simplified if pipe_instance_fixture covers its needs.
     # For this specific test, let's keep its original detailed setup to show the direct interactions.
     mock_gemini_client_instance = MagicMock()
-    mock_functions_module.Functions.get_function_valves_by_id.reset_mock()
-    mock_functions_module.Functions.get_function_valves_by_id.return_value = (
-        mock_pipe_valves_data
-    )
+    # mock_functions_module.Functions.get_function_valves_by_id.reset_mock() # Removed
+    # mock_functions_module.Functions.get_function_valves_by_id.return_value = ( # Removed
+    #     mock_pipe_valves_data
+    # )
 
     with patch(
         "plugins.pipes.gemini_manifold.genai.Client",
@@ -93,21 +100,29 @@ def test_pipe_initialization_with_api_key(mock_pipe_valves_data):
     ) as mock_internal_add_log_handler, patch(
         "sys.stdout", MagicMock()
     ):
-        pipe_instance = Pipe()
+        try:
+            pipe_instance = Pipe()
+            pipe_instance.valves = Pipe.Valves(**mock_pipe_valves_data) # Added
 
-        mock_functions_module.Functions.get_function_valves_by_id.assert_called_once_with(
-            "gemini_manifold_google_genai"
-        )
-        assert isinstance(pipe_instance.valves, Pipe.Valves)
-        assert pipe_instance.valves.GEMINI_API_KEY == "test_default_api_key_from_valves"
-        mock_internal_add_log_handler.assert_called_once()
-        MockedGenAIClientConstructor.assert_called_once_with(
-            api_key="test_default_api_key_from_valves",
-            http_options=gemini_types.HttpOptions(
-                base_url="https://test.googleapis.com"
-            ),
-        )
-        assert pipe_instance.clients["default"] == mock_gemini_client_instance
+            # mock_functions_module.Functions.get_function_valves_by_id.assert_called_once_with( # Removed
+            #     "gemini_manifold_google_genai"
+            # )
+            assert isinstance(pipe_instance.valves, Pipe.Valves)
+            assert pipe_instance.valves.GEMINI_API_KEY == "test_default_api_key_from_valves"
+            # mock_internal_add_log_handler.assert_called_once() # Removed
+
+            # Trigger client creation
+            pipe_instance._get_user_client(pipe_instance.valves, "test_user_email@example.com")
+
+            MockedGenAIClientConstructor.assert_called_once_with(
+                api_key="test_default_api_key_from_valves",
+                http_options=gemini_types.HttpOptions(
+                    base_url="https://test.googleapis.com"
+                ),
+            )
+            # assert pipe_instance.clients["default"] == mock_gemini_client_instance # Removed as per instructions
+        finally:
+            Pipe._get_or_create_genai_client.cache_clear()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The tests were failing due to two main reasons:
1. Unhandled caching for `_get_or_create_genai_client` (functools.cache) and `_get_genai_models` (aiocache), leading to state leakage between tests.
2. Test logic did not align with changes in the `Pipe` class's initialization, specifically how `Pipe.valves` are populated and how the `genai.Client` is lazily initialized.

This commit addresses these issues by:
- Modifying `test_pipe_initialization_with_api_key` to clear the `_get_or_create_genai_client` cache and to correctly trigger the lazy client initialization before asserting mock calls.
- Refactoring the `pipe_instance_fixture` to be asynchronous and to clear both `_get_or_create_genai_client.cache_clear()` and `_get_genai_models.cache.clear()` in its teardown phase. This ensures tests using the fixture are properly isolated.
- Removing incorrect assertions and mock setups related to `Functions.get_function_valves_by_id`, as this is no longer used for `Pipe.valves` initialization. Tests now directly set `pipe.valves` with test data.
- Adjusting `test_pipe_initialization_with_api_key` to reflect the lazy loading of the `genai.Client`, by adding a call to `_get_user_client` to trigger client creation.

All tests, except for the known failing `test_genai_contents_from_messages_youtube_link_mixed_with_text`, now pass.