### PR TITLE
fix(companion): add requirements.

### DIFF
--- a/plugins/filters/gemini_manifold_companion.py
+++ b/plugins/filters/gemini_manifold_companion.py
@@ -7,6 +7,7 @@ author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions
 license: MIT
 version: 1.5.0
+requirements: google-genai==1.16.1
 """
 
 # This filter can detect that a feature like web search or code execution is enabled in the front-end,


### PR DESCRIPTION
Suddenly Gemini stopped working on our instance.
We were seeing this in the logs:
```
ImportError: cannot import name 'genai' from 'google' (unknown location)
ModuleNotFoundError: No module named 'google.genai'
```

When someone more knowledgeable  than me investigated, they discovered that the companion needs the requirements too.
I'm not sure why it was working before, and why it broke, but this fixed the issue for us.