### PR TITLE
fix(gemini): Conditional usage of Files API

### DIFF
--- a/tests/test_gemini_manifold.py
+++ b/tests/test_gemini_manifold.py
@@ -961,6 +961,7 @@ async def test_builder_build_contents_user_text_with_pdf(pipe_instance_fixture):
 
     # Create a mock for the new dependency and its methods
     mock_files_api_manager = AsyncMock()
+    mock_files_api_manager.client.vertexai = False
     mock_gemini_file = MagicMock()
     mock_gemini_file.uri = "gs://fake-bucket/fake-file.pdf"
     mock_gemini_file.mime_type = pdf_mime_type


### PR DESCRIPTION
closes #171

Files API will not be used if one of these is true:

- new valves option `USE_FILES_API` is False
- user is using Vertex AI
- Temporary chat is enabled