### PR TITLE
fix(gemini): don't emit messages if `pipe` is run by an OWUI task model

### DIFF
--- a/utils/manifold_types.py
+++ b/utils/manifold_types.py
@@ -197,6 +197,8 @@ class Metadata(TypedDict):
     variables: MetadataVariables  # Using the specific MetadataVariables TypedDict
     model: MetadataModel  # Using the specific MetadataModel TypedDict
     direct: bool
+    task: str | None
+    task_body: dict[str, Any] | None
 
     # This is my custom field, not used by Open WebUI.
     safety_settings: list[types.SafetySetting]


### PR DESCRIPTION
This is kind of a bandage solution for #176. It just removes the toast message from the front-end while the console still logs warnings. Good enough for now.