### PR TITLE
refactor(gemini): Unified Pipe Response Processing & Companion Filter Enhancements

### DIFF
--- a/plugins/filters/gemini_manifold_companion.py
+++ b/plugins/filters/gemini_manifold_companion.py
@@ -88,6 +88,12 @@ log = logger.bind(auditable=False)
 class Filter:
 
     class Valves(BaseModel):
+        FORCE_NON_STREAM_FOR_IMAGE_MODELS: bool = Field(
+            default=True,
+            description="""Automatically disable streaming for image generation models
+            (e.g., gemini-2.5-flash-image-preview) to prevent 'Chunk too big' errors.
+            Set to False to attempt streaming with these models.""",
+        )
         SET_TEMP_TO_ZERO: bool = Field(
             default=False,
             description="""Decide if you want to set the temperature to 0 for grounded answers,
@@ -225,13 +231,34 @@ class Filter:
         else:
             metadata_features["upload_documents"] = False
 
-        # Force the backend down the streaming path, manifold pipe requires it to work.
-        # User's original intent is preserved into __metadata__.
-        # TODO: Image generation models can be set to non-streaming here.
+        # The manifold pipe requires the backend to be in streaming mode to correctly
+        # process the AsyncGenerator it returns. We save the user's original
+        # streaming intent and then force the backend into streaming mode.
+
+        user_stream_intent = body.get("stream", True)
+        image_generation_models = {
+            "gemini-2.0-flash-preview-image-generation",
+            "gemini-2.5-flash-image-preview",
+        }
+
+        # Check if the current model is an image generation model and if the
+        # user has enabled the non-streaming override for them.
+        if (
+            self.valves.FORCE_NON_STREAM_FOR_IMAGE_MODELS
+            and canonical_model_name in image_generation_models
+        ):
+            log.info(
+                f"Image generation model '{canonical_model_name}' detected. "
+                "Forcing non-streaming mode to prevent potential 'Chunk too big' errors."
+            )
+            # Override the user's intent to ensure stability.
+            user_stream_intent = False
+
         log.info(
-            f'Storing original stream value ({body["stream"]}) into __metadata__. Backend will be forced down the streaming path.'
+            f"Storing user's stream intent ({user_stream_intent}) into __metadata__. "
+            "Backend will be forced down the streaming path."
         )
-        metadata_features["stream"] = body.get("stream", True)
+        metadata_features["stream"] = user_stream_intent
         body["stream"] = True
 
         # TODO: Filter out the citation markers here.

--- a/plugins/filters/gemini_manifold_companion.py
+++ b/plugins/filters/gemini_manifold_companion.py
@@ -225,6 +225,15 @@ class Filter:
         else:
             metadata_features["upload_documents"] = False
 
+        # Force the backend down the streaming path, manifold pipe requires it to work.
+        # User's original intent is preserved into __metadata__.
+        # TODO: Image generation models can be set to non-streaming here.
+        log.info(
+            f'Storing original stream value ({body["stream"]}) into __metadata__. Backend will be forced down the streaming path.'
+        )
+        metadata_features["stream"] = body.get("stream", True)
+        body["stream"] = True
+
         # TODO: Filter out the citation markers here.
 
         return body

--- a/utils/manifold_types.py
+++ b/utils/manifold_types.py
@@ -179,6 +179,7 @@ class Features(TypedDict):
     upload_documents: NotRequired[bool]
     reason: NotRequired[bool]
     url_context: NotRequired[bool]
+    stream: NotRequired[bool]
 
 
 class Metadata(TypedDict):


### PR DESCRIPTION
This PR introduces significant refactoring to the Gemini manifold pipe and its companion filter, primarily aimed at unifying response processing and improving stream handling robustness.

Previously, the `Pipe.pipe()` method contained duplicated logic for handling streaming and non-streaming responses. Additionally, the Open WebUI backend's `generate_function_chat_completion` function had distinct, incompatible paths for `stream=True` and `stream=False`, leading to malformed outputs when our pipe returned an `AsyncGenerator` in a non-streaming context.

To address this, a new `_unified_response_processor` method has been introduced. This method now consistently processes an `AsyncIterator[types.GenerateContentResponse]`, regardless of whether it originates from a live stream or an adapted single API response. This eliminates code duplication and ensures a single source of truth for response parsing, tag substitution tracking, and post-processing.

The companion filter now plays a crucial role by intercepting incoming requests. It transparently forces `body['stream'] = True` for all Gemini manifold requests, ensuring the Open WebUI backend always utilizes its streaming response path, which is capable of correctly consuming the `AsyncGenerator` returned by our pipe. The user's original streaming intent is preserved in `__metadata__['features']['stream']` for the pipe's internal logic.

Furthermore, a new `FORCE_NON_STREAM_FOR_IMAGE_MODELS` valve has been added to the companion filter. When enabled, this automatically sets the user's original streaming intent to `False` for specific native image generation models. This mitigates "Chunk too big" errors observed when streaming large image tokens, ensuring these models function reliably without requiring manual user intervention.

The result is a cleaner, more robust, and more consistent internal architecture for the Gemini manifold, with improved error handling for problematic model responses.