### PR TITLE
fix(gemini): emit `data: [DONE]` stream terminator for quick action compatibility

### DIFF
--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -2453,6 +2453,7 @@ class Pipe:
                 event_emitter.emit_toast(toast_msg, "info")
 
             if not error_occurred:
+                yield "data: [DONE]"
                 log.info("Response processing finished successfully!")
 
             try:


### PR DESCRIPTION
Fixes the "add" button not appearing for streaming floating quick action responses. 