### PR TITLE
fix(gemini): Update default `THINKING_MODEL_PATTERN`

### DIFF
--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -1479,9 +1479,9 @@ class Pipe:
             Default value is True.""",
         )
         THINKING_MODEL_PATTERN: str = Field(
-            default=r"^(?=.*gemini-2.5)(?!.*live)(?!.*image)",
+            default=r"^(?=.*(?:gemini-2\.5|gemini-flash-latest|gemini-flash-lite-latest))(?!(.*live))(?!(.*image))",
             description="""Regex pattern to identify thinking models.
-            Default value is r"^(?=.*gemini-2.5)(?!.*live)(?!.*image)".""",
+            Default value is r"^(?=.*(?:gemini-2\.5|gemini-flash-latest|gemini-flash-lite-latest))(?!(.*live))(?!(.*image))".""",
         )
         IMAGE_MODEL_PATTERN: str = Field(
             default=r"image",


### PR DESCRIPTION
Updated `THINKING_MODEL_PATTERN` to catch the `gemini-flash-latest` and `gemini-flast-lite-latest` model codes. 

Not sure if this is the most elegant regex solution so I'm open to suggestions, but it has been working in my instance.