### PR TITLE
Add Gemini 3 Pro Preview support

### DIFF
--- a/plugins/filters/gemini_manifold_companion.py
+++ b/plugins/filters/gemini_manifold_companion.py
@@ -6,10 +6,10 @@ author: suurt8ll
 author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions
 license: MIT
-version: 1.7.0
+version: 1.7.1
 """
 
-VERSION = "1.7.0"
+VERSION = "1.7.1"
 
 # This filter can detect that a feature like web search or code execution is enabled in the front-end,
 # set the feature back to False so Open WebUI does not run it's own logic and then
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 # According to https://ai.google.dev/gemini-api/docs/models
 ALLOWED_GROUNDING_MODELS = {
+    "gemini-3-pro-preview",
     "gemini-2.5-pro",
     "gemini-flash-latest",
     "gemini-2.5-flash-preview-09-2025",
@@ -65,6 +66,7 @@ ALLOWED_GROUNDING_MODELS = {
     "gemini-1.0-pro",
 }
 ALLOWED_CODE_EXECUTION_MODELS = {
+    "gemini-3-pro-preview",
     "gemini-2.5-pro",
     "gemini-flash-latest",
     "gemini-2.5-flash-preview-09-2025",

--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -6,15 +6,15 @@ author: suurt8ll
 author_url: https://github.com/suurt8ll
 funding_url: https://github.com/suurt8ll/open_webui_functions
 license: MIT
-version: 1.26.0
+version: 1.27.0
 requirements: google-genai==1.49.0
 """
 
-VERSION = "1.26.0"
+VERSION = "1.27.0"
 # This is the recommended version for the companion filter.
 # Older versions might still work, but backward compatibility is not guaranteed
 # during the development of this personal use plugin.
-RECOMMENDED_COMPANION_VERSION = "1.7.0"
+RECOMMENDED_COMPANION_VERSION = "1.7.1"
 
 
 # Keys `title`, `id` and `description` in the frontmatter above are used for my own development purposes.
@@ -1531,9 +1531,9 @@ class Pipe:
             Titles are emitted as status updates and hidden when thinking ends.""",
         )
         THINKING_MODEL_PATTERN: str = Field(
-            default=r"^(?=.*(?:gemini-2\.5|gemini-flash-latest|gemini-flash-lite-latest))(?!(.*live))(?!(.*image))",
+            default=r"^(?=.*(?:gemini-2\.5|gemini-flash-latest|gemini-flash-lite-latest|gemini-3-pro-preview))(?!(.*live))(?!(.*image))",
             description="""Regex pattern to identify thinking models.
-            Default value is r"^(?=.*(?:gemini-2\.5|gemini-flash-latest|gemini-flash-lite-latest))(?!(.*live))(?!(.*image))".""",
+            Default value is r"^(?=.*(?:gemini-2\.5|gemini-flash-latest|gemini-flash-lite-latest|gemini-3-pro-preview))(?!(.*live))(?!(.*image))".""",
         )
         IMAGE_MODEL_PATTERN: str = Field(
             default=r"image",


### PR DESCRIPTION
Well, that finally happened!

Gemini 3 Pro Preview supports both **web search** and **code execution**. 

⚠️  Important:
- Don't forget to update both Gemini Manifold and Gemini Manifold Companion.
- If your Manifold's `THINKING_MODEL_PATTERN` setting was set to Custom, either reset it to Default or update to include `gemini-3-pro-preview`, otherwise you won't see the thinking process.
- If your Manifold Companion is not global for some reason, make sure it's enabled for Gemini 3 Pro Preview.

Happy Tuesday everyone! 🎉 