### PR TITLE
feat(filters): 2 small utility filters

### DIFF
--- a/plugins/filters/remove_reasoning.py
+++ b/plugins/filters/remove_reasoning.py
@@ -1,0 +1,37 @@
+"""
+title: Remove Reasoning
+description: Filter function to remove reasoning from the response.
+id: remove_reasoning
+author: suurt8ll
+author_url: https://github.com/suurt8ll
+funding_url: https://github.com/suurt8ll/open_webui_functions
+version: 1.0.0
+"""
+
+import datetime
+import inspect
+
+
+class Filter:
+
+    def __init__(self):
+        self.toggle = True  # Makes the filter toggleable in the front-end.
+        # Icon from https://icon-sets.iconify.design/mdi/brain/
+        self.icon = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPgoJPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIgLz4KCTxwYXRoIGZpbGw9ImN1cnJlbnRDb2xvciIgZD0iTTIxLjMzIDEyLjkxYy4wOSAxLjU1LS42MiAzLjA0LTEuODkgMy45NWwuNzcgMS40OWMuMjMuNDUuMjYuOTguMDYgMS40NWMtLjE5LjQ3LS41OC44NC0xLjA2IDFsLS43OS4yNWExLjY5IDEuNjkgMCAwIDEtMS44Ni0uNTVMMTQuNDQgMThjLS44OS0uMTUtMS43My0uNTMtMi40NC0xLjFjLS41LjE1LTEgLjIzLTEuNS4yM2MtLjg4IDAtMS43Ni0uMjctMi41LS43OWMtLjUzLjE2LTEuMDcuMjMtMS42Mi4yMmMtLjc5LjAxLTEuNTctLjE1LTIuMy0uNDVhNC4xIDQuMSAwIDAgMS0yLjQzLTMuNjFjLS4wOC0uNzIuMDQtMS40NS4zNS0yLjExYy0uMjktLjc1LS4zMi0xLjU3LS4wNy0yLjMzQzIuMyA3LjExIDMgNi4zMiAzLjg3IDUuODJjLjU4LTEuNjkgMi4yMS0yLjgyIDQtMi43YzEuNi0xLjUgNC4wNS0xLjY2IDUuODMtLjM3Yy40Mi0uMTEuODYtLjE3IDEuMy0uMTdjMS4zNi0uMDMgMi42NS41NyAzLjUgMS42NGMyLjA0LjUzIDMuNSAyLjM1IDMuNTggNC40N2MuMDUgMS4xMS0uMjUgMi4yLS44NiAzLjEzYy4wNy4zNi4xMS43Mi4xMSAxLjA5bS01LTEuNDFjLjU3LjA3IDEuMDIuNSAxLjAyIDEuMDdhMSAxIDAgMCAxLTEgMWgtLjYzYy0uMzIuOS0uODggMS42OS0xLjYyIDIuMjljLjI1LjA5LjUxLjE0Ljc3LjIxYzUuMTMtLjA3IDQuNTMtMy4yIDQuNTMtMy4yNWEyLjU5IDIuNTkgMCAwIDAtMi42OS0yLjQ5YTEgMSAwIDAgMS0xLTFhMSAxIDAgMCAxIDEtMWMxLjIzLjAzIDIuNDEuNDkgMy4zMyAxLjNjLjA1LS4yOS4wOC0uNTkuMDgtLjg5Yy0uMDYtMS4yNC0uNjItMi4zMi0yLjg3LTIuNTNjLTEuMjUtMi45Ni00LjQtMS4zMi00LjQtLjRjLS4wMy4yMy4yMS43Mi4yNS43NWExIDEgMCAwIDEgMSAxYzAgLjU1LS40NSAxLTEgMWMtLjUzLS4wMi0xLjAzLS4yMi0xLjQzLS41NmMtLjQ4LjMxLTEuMDMuNS0xLjYuNTZjLS41Ny4wNS0xLjA0LS4zNS0xLjA3LS45YS45Ny45NyAwIDAgMSAuODgtMS4xYy4xNi0uMDIuOTQtLjE0Ljk0LS43N2MwLS42Ni4yNS0xLjI5LjY4LTEuNzljLS45Mi0uMjUtMS45MS4wOC0yLjkxIDEuMjlDNi43NSA1IDYgNS4yNSA1LjQ1IDcuMkM0LjUgNy42NyA0IDggMy43OCA5YzEuMDgtLjIyIDIuMTktLjEzIDMuMjIuMjVjLjUuMTkuNzguNzUuNTkgMS4yOWMtLjE5LjUyLS43Ny43OC0xLjI5LjU5Yy0uNzMtLjMyLTEuNTUtLjM0LTIuMy0uMDZjLS4zMi4yNy0uMzIuODMtLjMyIDEuMjdjMCAuNzQuMzcgMS40MyAxIDEuODNjLjUzLjI3IDEuMTIuNDEgMS43MS40cS0uMjI1LS4zOS0uMzktLjgxYTEuMDM4IDEuMDM4IDAgMCAxIDEuOTYtLjY4Yy40IDEuMTQgMS40MiAxLjkyIDIuNjIgMi4wNWMxLjM3LS4wNyAyLjU5LS44OCAzLjE5LTIuMTNjLjIzLTEuMzggMS4zNC0xLjUgMi41Ni0xLjVtMiA3LjQ3bC0uNjItMS4zbC0uNzEuMTZsMSAxLjI1em0tNC42NS04LjYxYTEgMSAwIDAgMC0uOTEtMS4wM2MtLjcxLS4wNC0xLjQuMi0xLjkzLjY3Yy0uNTcuNTgtLjg3IDEuMzgtLjg0IDIuMTlhMSAxIDAgMCAwIDEgMWMuNTcgMCAxLS40NSAxLTFjMC0uMjcuMDctLjU0LjIzLS43NmMuMTItLjEuMjctLjE1LjQzLS4xNWMuNTUuMDMgMS4wMi0uMzggMS4wMi0uOTIiIC8+Cjwvc3ZnPgo="
+        self._log("Function has been initialized!")
+
+    def _log(self, message: str):
+        timestamp = datetime.datetime.now().isoformat()
+        caller_name = inspect.stack()[1].function
+        print(f"[{timestamp}] [{__name__}.{caller_name}] {message}")
+
+    async def stream(
+        self,
+        event: dict,
+    ) -> dict | None:
+        # if event.choices[0].delta contains key reasoning_content, remove it
+        if "choices" in event and len(event["choices"]) > 0:
+            for choice in event["choices"]:
+                if "delta" in choice and "reasoning_content" in choice["delta"]:
+                    del choice["delta"]["reasoning_content"]
+        return event

--- a/plugins/filters/venice_system_prompt_toggle.py
+++ b/plugins/filters/venice_system_prompt_toggle.py
@@ -1,0 +1,34 @@
+"""
+title: Disable Venice System Prompt
+description: Filter function to turn off the Venice.ai's default system prompt.
+id: disable_venice_system_prompt
+author: suurt8ll
+author_url: https://github.com/suurt8ll
+funding_url: https://github.com/suurt8ll/open_webui_functions
+version: 1.0.0
+"""
+
+import datetime
+import inspect
+
+
+class Filter:
+
+    def __init__(self):
+        self.toggle = True  # Makes the filter toggleable in the front-end.
+        # Icon from https://icon-sets.iconify.design/material-symbols/comments-disabled-outline-rounded/
+        self.icon = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPgoJPHBhdGggZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSIgLz4KCTxwYXRoIGZpbGw9ImN1cnJlbnRDb2xvciIgZD0iTTQgMThxLS44MjUgMC0xLjQxMi0uNTg3VDIgMTZWNC44MjVMMS4zNzUgNC4ycS0uMy0uMy0uMy0uNzEzdC4zLS43MTJ0LjcxMy0uM3QuNzEyLjNsMTguNCAxOC40cS4zLjMuMy43dC0uMy43dC0uNzEyLjN0LS43MTMtLjNMMTUuMTc1IDE4ek0yMiA0djEzLjkyNXEwIC4zNS0uMy40NzV0LS41NS0uMTI1TDE4Ljg3NSAxNkgyMFY0SDdxLS41IDAtLjc1LS4zMTJUNiAzdC4yNS0uNjg3VDcgMmgxM3EuODI1IDAgMS40MTMuNTg4VDIyIDRNNCAxNmg5LjE3NWwtMi0ySDdxLS40MjUgMC0uNzEyLS4yODhUNiAxM3QuMjg4LS43MTJUNyAxMmgyLjE3NWwtMS0xSDdxLS40MjUgMC0uNzEyLS4yODhUNiAxMHQuMjg4LS43MTJUNyA5aC42MjV2MS40NUw0IDYuODI1em0xNC0zcTAgLjQyNS0uMjg4LjcxM1QxNyAxNHQtLjcxMi0uMjg4VDE2IDEzdC4yODgtLjcxMlQxNyAxMnQuNzEzLjI4OFQxOCAxM20tMS0yaC0yLjdxLS41IDAtLjc1LS4zMTJUMTMuMyAxMHQuMjUtLjY4N1QxNC4zIDlIMTdxLjQyNSAwIC43MTMuMjg4VDE4IDEwdC0uMjg4LjcxM1QxNyAxMW0wLTNoLTUuN3EtLjUgMC0uNzUtLjMxMlQxMC4zIDd0LjI1LS42ODdUMTEuMyA2SDE3cS40MjUgMCAuNzEzLjI4OFQxOCA3dC0uMjg4LjcxM1QxNyA4bS00LjEyNSAyIiAvPgo8L3N2Zz4K"
+        self._log("Function has been initialized!")
+
+    def _log(self, message: str):
+        timestamp = datetime.datetime.now().isoformat()
+        caller_name = inspect.stack()[1].function
+        print(f"[{timestamp}] [{__name__}.{caller_name}] {message}")
+
+    async def inlet(
+        self,
+        body: dict,
+    ) -> dict:
+        self._log("Disabling Venice.ai's default system prompt.")
+        body["venice_parameters"] = {"include_venice_system_prompt": False}
+        return body


### PR DESCRIPTION
- `remove_reasoning`: drops reasoning from the model output. useful when doing blind ranking between 2 models for example.
- `venice_system_promt_toggle`: modifies the payload so the OWUI -> LiteLLM -> Venice.ai API request will not use Venice.ai's own system prompt