### PR TITLE
refactor: centralize logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The plugins are organized by type within the `plugins/` directory:
 -   `plugins/pipes/`: Pipe plugins that integrate custom models and behaviors.
     -   `gemini_manifold.py` | [Open WebUI Community](https://openwebui.com/f/suurt8ll/gemini_manifold_google_genai) | Provides support for Google's Gemini Studio API and Vertex AI. See the [Detailed Documentation](docs/plugins/pipes/gemini_manifold.md).
     -   `venice_manifold.py` | [Open WebUI Community](https://openwebui.com/f/suurt8ll/venice_image_generation) | Enables image creation using any diffusion model offered by Venice.ai API.
+    -   `dynamic_plugin_log_manager.py`: Dynamically injects and manages Loguru handlers with custom formatting for Open WebUI plugins. See the [Detailed Documentation](docs/plugins/pipes/dynamic_plugin_log_manager.md).
 -   `plugins/filters/`: Filter plugins that modify request and response data.
     -   `gemini_manifold_companion.py`: A companion filter for the Gemini Manifold pipe providing enhanced functionality like Google Search grounding. See the [Detailed Documentation](docs/plugins/filters/gemini_manifold_companion.md).
     -   `system_prompt_injector.py`: Allows changing chat options like system prompt and temperature directly from the chatbox. Pairs well with the Open WebUI "Prompts" feature.

--- a/docs/plugins/filters/gemini_manifold_companion.md
+++ b/docs/plugins/filters/gemini_manifold_companion.md
@@ -36,7 +36,6 @@ The filter is configured via a "Valves" settings menu accessible by clicking the
     *   **Custom:** Allows specifying a custom threshold value. Consult the Google documentation for information on acceptable values and their impact. This setting is only supported for Gemini 1.0 and 1.5 models.
 *   **USE_PERMISSIVE_SAFETY:** *(Enabled/Disabled)* When enabled, the filter will add permissive safety settings to the request payload, potentially allowing the model to generate responses that might otherwise be blocked by default safety filters. Refer to Google's safety settings documentation for details.
 *   **BYPASS_BACKEND_RAG:** *(Enabled/Disabled)* When enabled, the filter intercepts document uploads, prevents Open WebUI's backend RAG from processing them, and signals the `gemini_manifold.py` pipe to handle the raw documents directly with the Gemini API. **Note: This feature is not supported in temporary ('local') chats.**
-*   **LOG_LEVEL:** *(TRACE/DEBUG/INFO/SUCCESS/WARNING/ERROR/CRITICAL)* Controls the logging verbosity of this specific filter. Use `docker logs -f open-webui` to view logs.
 
 ## Usage
 

--- a/docs/plugins/pipes/dynamic_plugin_log_manager.md
+++ b/docs/plugins/pipes/dynamic_plugin_log_manager.md
@@ -1,0 +1,86 @@
+# `dynamic_plugin_log_manager.py` - Detailed Documentation
+
+A centralised Loguru handler injector for Open WebUI plugins. It eliminates the need to copy-paste custom logging logic into every plugin you write.
+
+## How it works
+
+1. **Triggered on every model list refresh** — OWUI calls `pipes()` on every enabled `Pipe` when the front-end saves or refreshes; the log handler sync runs inside `pipes()`.
+
+2. **Reads a JSON config from Valves** — each key is a *function ID* (as set in the target plugin's `Valves` → `id`), each value is a `loguru` level (`TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`).
+
+3. **Injects / updates Loguru handlers** — for each configured function ID it creates a dedicated handler that:
+   - only captures logs from `function_<id>` (via filter on `record["name"]`)
+   - uses the compact, truncating format shown below
+   - respects `auditable=False` (the standard OWUI trick to avoid double-printing, see OWUI `start_logger`)
+
+4. **Removes stale handlers** — if you remove a function from the config or change its level, the old handler is cleaned up on the next refresh.
+
+## Configuration
+
+Open the Pipe's Valves and set `FUNCTIONS_LOG_LEVELS` to a JSON object like:
+
+```json
+{
+  "gemini_manifold_companion": "DEBUG",
+  "my_custom_filter": "INFO"
+}
+```
+
+The ID is the string you gave in the target plugin's docstring header (`id: gemini_manifold_companion`). The plugin internally prepends `function_` if missing.
+
+## Using the format in your own plugin
+
+> If you **don't** want the custom format, you don't need to do anything — the handler still works and your logs appear with normal OWUI formatting.  
+> The extras below are **optional** and only needed if you want structured payload serialisation.
+
+In the target plugin (e.g. `gemini_manifold_companion`), get a bound logger:
+
+```python
+from loguru import logger
+
+log = logger.bind(auditable=False)
+```
+
+Now use `log.info`, `log.debug`, etc. as usual.
+
+### Structured payload logging (optional)
+
+To attach serialisable data to a log line:
+
+```python
+log.info("Request finished", payload={
+    "status": 200, "model": "gemini-2.0-flash", "tokens": 145
+})
+```
+
+The plugin's format function will:
+- serialise the payload via `pydantic_core.to_jsonable_python`
+- flatten compact JSON for flat dicts (single line), pretty‑print nested ones
+- truncate long strings to 256 chars by default (can be overridden via extras – see below)
+
+### Controlling truncation per call
+
+Add these to `extra` on the log call (or bind them once on the logger):
+
+| Extra key | Type | Default | Behaviour |
+|-----------|------|---------|-----------|
+| `_log_truncation_enabled` | `bool` | `True` | Set `False` to disable truncation |
+| `_log_max_length` | `int` | `256` | Truncation max length |
+| `_log_truncation_marker` | `str` | `[...]` | Suffix appended when truncated |
+
+Example:
+
+```python
+log.warning("Large response", payload=data,
+            _log_truncation_enabled=True, _log_max_length=512)
+```
+
+## Caveats / prerequisites
+
+1. **OWUI must call `pipes()` on save.** This is true for current OWUI versions – every front-end model list refresh triggers `pipes()` on all enabled Pipes. If this behaviour changes upstream the plugin will stop working silently (log handlers won't be injected).
+
+2. **The `auditable=False` bind trick** assumes OWUI's built-in `stdout_format` / `_json_sink` filters out entries whose `extra` contains `'auditable'` (by default it does). If a future OWUI version changes this filter, logs may appear duplicated.
+
+3. **The plugin itself is a Pipe** — it must be **enabled** in the admin panel for the handlers to be active. Disabling it removes all managed handlers on the next refresh cycle.
+
+4. **Manual refresh** – if you change the JSON config while OWUI is running and want immediate effect without waiting for a save event, open the Valves panel and click **Save** — this triggers the refresh.

--- a/plugins/filters/gemini_manifold_companion.py
+++ b/plugins/filters/gemini_manifold_companion.py
@@ -15,12 +15,7 @@ VERSION = "2.1.0"
 # set the feature back to False so Open WebUI does not run it's own logic and then
 # pass custom values to "Gemini Manifold google_genai" that signal which feature was enabled and intercepted.
 
-import copy
 import functools
-import json
-from google.genai import types
-
-import sys
 import time
 import asyncio
 import urllib.request
@@ -29,14 +24,12 @@ from fastapi import Request
 from fastapi.datastructures import State
 from loguru import logger
 from pydantic import BaseModel, Field
-import pydantic_core
 import yaml
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal, TYPE_CHECKING, cast
+from google.genai import types
 
 if TYPE_CHECKING:
-    from loguru import Record
-    from loguru._handler import Handler  # type: ignore
     from utils.manifold_types import *  # My personal types in a separate file for more robustness.
 
 # Setting auditable=False avoids duplicate output for log levels that would be printed out by the main log.
@@ -257,11 +250,7 @@ _SHARED_VALVE_DESCS = {
     ),
 }
 
-_ADMIN_VALVE_DESCS = {
-    "LOG_LEVEL": (
-        "Select logging verbosity level. View logs using `docker logs -f open-webui`."
-    ),
-}
+_ADMIN_VALVE_DESCS = {}
 
 
 def _format_valve_desc(text: str, default: Any = None, is_user: bool = False) -> str:
@@ -324,14 +313,6 @@ class Filter:
             description=_format_valve_desc(
                 _SHARED_VALVE_DESCS["STATUS_EMISSION_BEHAVIOR"],
                 default="hidden_detailed",
-            ),
-        )
-        LOG_LEVEL: Literal[
-            "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"
-        ] = Field(
-            default="INFO",
-            description=_format_valve_desc(
-                _ADMIN_VALVE_DESCS["LOG_LEVEL"], default="INFO"
             ),
         )
 
@@ -402,9 +383,6 @@ class Filter:
         __user__: dict[str, Any] | None = None,
     ) -> "Body":
         """Modifies the incoming request payload before it's sent to the LLM. Operates on the `form_data` dictionary."""
-
-        self._add_log_handler()
-
         log.debug(
             f"inlet method has been called. Gemini Manifold Companion version is {VERSION}"
         )
@@ -1256,231 +1234,6 @@ class Filter:
 
         # 6. Return the canonical name and the manifold flag
         return canonical_model_name, is_manifold_model
-
-    def _is_flat_dict(self, data: Any) -> bool:
-        """
-        Checks if a dictionary contains only non-dict/non-list values (is one level deep).
-        """
-        if not isinstance(data, dict):
-            return False
-        return not any(isinstance(value, (dict, list)) for value in data.values())
-
-    def _truncate_long_strings(
-        self, data: Any, max_len: int, truncation_marker: str, truncation_enabled: bool
-    ) -> Any:
-        """
-        Recursively traverses a data structure (dicts, lists) and truncates
-        long string values. Creates copies to avoid modifying original data.
-
-        Args:
-            data: The data structure (dict, list, str, int, float, bool, None) to process.
-            max_len: The maximum allowed length for string values.
-            truncation_marker: The string to append to truncated values.
-            truncation_enabled: Whether truncation is enabled.
-
-        Returns:
-            A potentially new data structure with long strings truncated.
-        """
-        if not truncation_enabled or max_len <= len(truncation_marker):
-            # If truncation is disabled or max_len is too small, return original
-            # Make a copy only if it's a mutable type we might otherwise modify
-            if isinstance(data, (dict, list)):
-                return copy.deepcopy(data)  # Ensure deep copy for nested structures
-            return data  # Primitives are immutable
-
-        if isinstance(data, str):
-            if len(data) > max_len:
-                return data[: max_len - len(truncation_marker)] + truncation_marker
-            return data  # Return original string if not truncated
-        elif isinstance(data, dict):
-            # Process dictionary items, creating a new dict
-            return {
-                k: self._truncate_long_strings(
-                    v, max_len, truncation_marker, truncation_enabled
-                )
-                for k, v in data.items()
-            }
-        elif isinstance(data, list):
-            # Process list items, creating a new list
-            return [
-                self._truncate_long_strings(
-                    item, max_len, truncation_marker, truncation_enabled
-                )
-                for item in data
-            ]
-        else:
-            # Return non-string, non-container types as is (they are immutable)
-            return data
-
-    def plugin_stdout_format(self, record: "Record") -> str:
-        """
-        Custom format function for the plugin's logs.
-        Serializes and truncates data passed under the 'payload' key in extra.
-        """
-
-        # Configuration Keys
-        LOG_OPTIONS_PREFIX = "_log_"
-        TRUNCATION_ENABLED_KEY = f"{LOG_OPTIONS_PREFIX}truncation_enabled"
-        MAX_LENGTH_KEY = f"{LOG_OPTIONS_PREFIX}max_length"
-        TRUNCATION_MARKER_KEY = f"{LOG_OPTIONS_PREFIX}truncation_marker"
-        DATA_KEY = "payload"
-
-        original_extra = record["extra"]
-        # Extract the data intended for serialization using the chosen key
-        data_to_process = original_extra.get(DATA_KEY)
-
-        serialized_data_json = ""
-        if data_to_process is not None:
-            try:
-                serializable_data = pydantic_core.to_jsonable_python(
-                    data_to_process, serialize_unknown=True
-                )
-
-                # Determine truncation settings
-                truncation_enabled = original_extra.get(TRUNCATION_ENABLED_KEY, True)
-                max_length = original_extra.get(MAX_LENGTH_KEY, 256)
-                truncation_marker = original_extra.get(TRUNCATION_MARKER_KEY, "[...]")
-
-                # If max_length was explicitly provided, force truncation enabled
-                if MAX_LENGTH_KEY in original_extra:
-                    truncation_enabled = True
-
-                # Truncate long strings
-                truncated_data = self._truncate_long_strings(
-                    serializable_data,
-                    max_length,
-                    truncation_marker,
-                    truncation_enabled,
-                )
-
-                # Serialize the (potentially truncated) data
-                if self._is_flat_dict(truncated_data) and not isinstance(
-                    truncated_data, list
-                ):
-                    json_string = json.dumps(
-                        truncated_data, separators=(",", ":"), default=str
-                    )
-                    # Add a simple prefix if it's compact
-                    serialized_data_json = " - " + json_string
-                else:
-                    json_string = json.dumps(truncated_data, indent=2, default=str)
-                    # Prepend with newline for readability
-                    serialized_data_json = "\n" + json_string
-
-            except (TypeError, ValueError) as e:  # Catch specific serialization errors
-                serialized_data_json = f" - {{Serialization Error: {e}}}"
-            except (
-                Exception
-            ) as e:  # Catch any other unexpected errors during processing
-                serialized_data_json = f" - {{Processing Error: {e}}}"
-
-        # Add the final JSON string (or error message) back into the record
-        record["extra"]["_plugin_serialized_data"] = serialized_data_json
-
-        # Base template
-        base_template = (
-            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-            "<level>{level: <8}</level> | "
-            "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
-            "<level>{message}</level>"
-        )
-
-        # Append the serialized data
-        base_template += "{extra[_plugin_serialized_data]}"
-        # Append the exception part
-        base_template += "\n{exception}"
-        # Return the format string template
-        return base_template.rstrip()
-
-    def _add_log_handler(self):
-        """
-        Adds or updates the loguru handler specifically for this plugin.
-        Includes logic for serializing and truncating extra data.
-        """
-
-        def plugin_filter(record: "Record"):
-            """Filter function to only allow logs from this plugin (based on module name)."""
-            return record["name"] == __name__
-
-        # Get the desired level name and number
-        desired_level_name = self.valves.LOG_LEVEL
-        try:
-            # Use the public API to get level details
-            desired_level_info = log.level(desired_level_name)
-            desired_level_no = desired_level_info.no
-        except ValueError:
-            log.error(
-                f"Invalid LOG_LEVEL '{desired_level_name}' configured for plugin {__name__}. Cannot add/update handler."
-            )
-            return  # Stop processing if the level is invalid
-
-        # Access the internal state of the log
-        handlers: dict[int, "Handler"] = log._core.handlers  # type: ignore
-        handler_id_to_remove = None
-        found_correct_handler = False
-
-        for handler_id, handler in handlers.items():
-            existing_filter = handler._filter  # Access internal attribute
-
-            # Check if the filter matches our plugin_filter
-            # Comparing function objects directly can be fragile if they are recreated.
-            # Comparing by name and module is more robust for functions defined at module level.
-            is_our_filter = (
-                existing_filter is not None  # Make sure a filter is set
-                and hasattr(existing_filter, "__name__")
-                and existing_filter.__name__ == plugin_filter.__name__
-                and hasattr(existing_filter, "__module__")
-                and existing_filter.__module__ == plugin_filter.__module__
-            )
-
-            if is_our_filter:
-                existing_level_no = handler.levelno
-                log.trace(
-                    f"Found existing handler {handler_id} for {__name__} with level number {existing_level_no}."
-                )
-
-                # Check if the level matches the desired level
-                if existing_level_no == desired_level_no:
-                    log.debug(
-                        f"Handler {handler_id} for {__name__} already exists with the correct level '{desired_level_name}'."
-                    )
-                    found_correct_handler = True
-                    break  # Found the correct handler, no action needed
-                else:
-                    # Found our handler, but the level is wrong. Mark for removal.
-                    log.info(
-                        f"Handler {handler_id} for {__name__} found, but log level differs "
-                        f"(existing: {existing_level_no}, desired: {desired_level_no}). "
-                        f"Removing it to update."
-                    )
-                    handler_id_to_remove = handler_id
-                    break  # Found the handler to replace, stop searching
-
-        # Remove the old handler if marked for removal
-        if handler_id_to_remove is not None:
-            try:
-                log.remove(handler_id_to_remove)
-                log.debug(f"Removed handler {handler_id_to_remove} for {__name__}.")
-            except ValueError:
-                # This might happen if the handler was somehow removed between the check and now
-                log.warning(
-                    f"Could not remove handler {handler_id_to_remove} for {__name__}. It might have already been removed."
-                )
-                # If removal failed but we intended to remove, we should still proceed to add
-                # unless found_correct_handler is somehow True (which it shouldn't be if handler_id_to_remove was set).
-
-        # Add a new handler if no correct one was found OR if we just removed an incorrect one
-        if not found_correct_handler:
-            self.log_level = desired_level_name
-            log.add(
-                sys.stdout,
-                level=desired_level_name,
-                format=self.plugin_stdout_format,
-                filter=plugin_filter,
-            )
-            log.debug(
-                f"Added new handler to loguru for {__name__} with level {desired_level_name}."
-            )
 
     # endregion 1.4 Utility helpers
 

--- a/plugins/pipes/dynamic_plugin_log_manager.py
+++ b/plugins/pipes/dynamic_plugin_log_manager.py
@@ -1,0 +1,215 @@
+"""
+title: Dynamic Plugin Log Manager
+id: dynamic_plugin_log_manager
+description: Dynamically injects and manages Loguru handlers with custom formatting for Open WebUI plugins.
+author: suurt8ll
+author_url: https://github.com/suurt8ll
+funding_url: https://github.com/suurt8ll/open_webui_functions
+license: MIT
+version: 1.0.0
+"""
+
+import copy
+import json
+import sys
+from typing import Any, TYPE_CHECKING
+import pydantic_core
+from loguru import logger
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from loguru import Record
+
+
+def _create_plugin_filter(target_module: str):
+    def filter_func(record: "Record") -> bool:
+        return record["name"] == target_module
+
+    filter_func.target_module = target_module  # type: ignore
+    return filter_func
+
+
+class Pipe:
+    class Valves(BaseModel):
+        FUNCTIONS_LOG_LEVELS: str = Field(
+            default='{}',
+            description="JSON object mapping function IDs to Loguru log levels (e.g. TRACE, DEBUG, INFO, WARNING, ERROR).",
+        )
+
+    def __init__(self):
+        self.valves = self.Valves()
+        logger.success("Function has been initialized.")
+
+    def _is_flat_dict(self, data: Any) -> bool:
+        if not isinstance(data, dict):
+            return False
+        return not any(isinstance(value, (dict, list)) for value in data.values())
+
+    def _truncate_long_strings(
+        self, data: Any, max_len: int, truncation_marker: str, truncation_enabled: bool
+    ) -> Any:
+        if not truncation_enabled or max_len <= len(truncation_marker):
+            if isinstance(data, (dict, list)):
+                return copy.deepcopy(data)
+            return data
+
+        if isinstance(data, str):
+            if len(data) > max_len:
+                return data[: max_len - len(truncation_marker)] + truncation_marker
+            return data
+        elif isinstance(data, dict):
+            return {
+                k: self._truncate_long_strings(
+                    v, max_len, truncation_marker, truncation_enabled
+                )
+                for k, v in data.items()
+            }
+        elif isinstance(data, list):
+            return [
+                self._truncate_long_strings(
+                    item, max_len, truncation_marker, truncation_enabled
+                )
+                for item in data
+            ]
+        else:
+            return data
+
+    def plugin_stdout_format(self, record: "Record") -> str:
+        LOG_OPTIONS_PREFIX = "_log_"
+        TRUNCATION_ENABLED_KEY = f"{LOG_OPTIONS_PREFIX}truncation_enabled"
+        MAX_LENGTH_KEY = f"{LOG_OPTIONS_PREFIX}max_length"
+        TRUNCATION_MARKER_KEY = f"{LOG_OPTIONS_PREFIX}truncation_marker"
+        DATA_KEY = "payload"
+
+        original_extra = record["extra"]
+        data_to_process = original_extra.get(DATA_KEY)
+
+        serialized_data_json = ""
+        if data_to_process is not None:
+            try:
+                serializable_data = pydantic_core.to_jsonable_python(
+                    data_to_process, serialize_unknown=True
+                )
+
+                truncation_enabled = original_extra.get(TRUNCATION_ENABLED_KEY, True)
+                max_length = original_extra.get(MAX_LENGTH_KEY, 256)
+                truncation_marker = original_extra.get(TRUNCATION_MARKER_KEY, "[...]")
+
+                if MAX_LENGTH_KEY in original_extra:
+                    truncation_enabled = True
+
+                truncated_data = self._truncate_long_strings(
+                    serializable_data,
+                    max_length,
+                    truncation_marker,
+                    truncation_enabled,
+                )
+
+                if self._is_flat_dict(truncated_data) and not isinstance(
+                    truncated_data, list
+                ):
+                    json_string = json.dumps(
+                        truncated_data, separators=(",", ":"), default=str
+                    )
+                    serialized_data_json = " - " + json_string
+                else:
+                    json_string = json.dumps(truncated_data, indent=2, default=str)
+                    serialized_data_json = "\n" + json_string
+
+            except (TypeError, ValueError) as e:
+                serialized_data_json = f" - {{Serialization Error: {e}}}"
+            except Exception as e:
+                serialized_data_json = f" - {{Processing Error: {e}}}"
+
+        record["extra"]["_plugin_serialized_data"] = serialized_data_json
+
+        base_template = (
+            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
+            "<level>{level: <8}</level> | "
+            "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
+            "<level>{message}</level>"
+            "{extra[_plugin_serialized_data]}\n"
+            "{exception}"
+        )
+        return base_template.rstrip()
+
+    def _sync_log_handlers(self) -> None:
+        if not self.valves.FUNCTIONS_LOG_LEVELS:
+            return
+
+        try:
+            config = json.loads(self.valves.FUNCTIONS_LOG_LEVELS)
+            if not isinstance(config, dict):
+                logger.error(
+                    "FUNCTIONS_LOG_LEVELS must be a JSON object mapping function IDs to log levels."
+                )
+                return
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse FUNCTIONS_LOG_LEVELS JSON: {e}")
+            return
+
+        target_levels: dict[str, str] = {}
+        for func_id, level_name in config.items():
+            if not isinstance(func_id, str) or not isinstance(level_name, str):
+                continue
+
+            clean_id = func_id.strip()
+            if not clean_id:
+                continue
+
+            module_name = (
+                clean_id if clean_id.startswith("function_") else f"function_{clean_id}"
+            )
+            level_name_upper = level_name.upper().strip()
+
+            try:
+                logger.level(level_name_upper)
+                target_levels[module_name] = level_name_upper
+            except ValueError:
+                logger.error(
+                    f"Invalid log level '{level_name}' configured for function '{func_id}'."
+                )
+
+        handlers: dict[int, Any] = logger._core.handlers  # type: ignore
+        active_managed_modules: set[str] = set()
+
+        for handler_id, handler in list(handlers.items()):
+            existing_filter = handler._filter
+            target_module = getattr(existing_filter, "target_module", None)
+
+            if target_module is not None:
+                desired_level = target_levels.get(target_module)
+
+                if desired_level is not None:
+                    desired_level_no = logger.level(desired_level).no
+                    if handler.levelno == desired_level_no:
+                        active_managed_modules.add(target_module)
+                        continue
+
+                try:
+                    logger.remove(handler_id)
+                    logger.info(
+                        f"Removed Loguru handler {handler_id} for module '{target_module}'."
+                    )
+                except ValueError:
+                    pass
+
+        for module_name, level_name in target_levels.items():
+            if module_name not in active_managed_modules:
+                plugin_filter = _create_plugin_filter(module_name)
+                logger.add(
+                    sys.stdout,
+                    level=level_name,
+                    format=self.plugin_stdout_format,
+                    filter=plugin_filter,
+                )
+                logger.success(
+                    f"Added Loguru handler for module '{module_name}' with level '{level_name}'."
+                )
+
+    async def pipes(self) -> list[dict]:
+        self._sync_log_handlers()
+        return []
+
+    async def pipe(self, body: dict) -> dict:
+        return body

--- a/plugins/pipes/gemini_manifold.py
+++ b/plugins/pipes/gemini_manifold.py
@@ -34,7 +34,6 @@ from google.api_core import exceptions
 
 import time
 import copy
-import json
 from urllib.parse import urlparse, parse_qs
 import xxhash
 import asyncio
@@ -52,7 +51,6 @@ import uuid
 import base64
 import re
 import fnmatch
-import sys
 import difflib
 from loguru import logger
 from fastapi import Request, FastAPI
@@ -76,8 +74,6 @@ from open_webui.utils.misc import pop_system_message
 
 # This block is skipped at runtime.
 if TYPE_CHECKING:
-    from loguru import Record
-    from loguru._handler import Handler  # type: ignore
     from plugins.filters.gemini_manifold_companion import EventEmitter
     # Imports custom type definitions (TypedDicts) for static analysis purposes (mypy/pylance).
     from utils.manifold_types import *
@@ -1589,7 +1585,6 @@ _ADMIN_VALVE_DESCS = {
     ),
     "CACHE_MODELS": "Whether to cache available models on startup and refresh only when whitelist or blacklist rules change.",
     "USE_ENTERPRISE_SEARCH": "Enable Enterprise Search tool allowing models to fetch and ground content from specified web URLs.",
-    "LOG_LEVEL": "Logging verbosity level. View logs using `docker logs -f open-webui`.",
 }
 
 
@@ -1752,14 +1747,6 @@ class Pipe:
                 _SHARED_VALVE_DESCS["MAPS_GROUNDING_COORDINATES"], default=None
             ),
         )
-        LOG_LEVEL: Literal[
-            "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"
-        ] = Field(
-            default="INFO",
-            description=_format_valve_desc(
-                _ADMIN_VALVE_DESCS["LOG_LEVEL"], default="INFO"
-            ),
-        )
         IMAGE_RESOLUTION: Literal["1K", "2K", "4K"] = Field(
             default="1K",
             description=_format_valve_desc(
@@ -1920,7 +1907,6 @@ class Pipe:
 
     async def pipes(self) -> list["ModelData"]:
         """Register all available Google models."""
-        self._add_log_handler(self.valves.LOG_LEVEL)
         log.debug("pipes method has been called.")
 
         # Clear cache if caching is disabled
@@ -1954,8 +1940,6 @@ class Pipe:
         __metadata__: "Metadata",
     ) -> AsyncGenerator[dict | str, None] | dict:
 
-        self._add_log_handler(self.valves.LOG_LEVEL)
-
         log.debug(
             f"pipe method has been called. Gemini Manifold google_genai version is {VERSION}"
         )
@@ -1967,7 +1951,7 @@ class Pipe:
 
         # Retrieve model configuration from app state
         app_state: State = __request__.app.state
-        model_config: dict[str, Any] = app_state._state.get("gemini_model_config")
+        model_config: dict[str, Any] | None = app_state._state.get("gemini_model_config")
         # FIXME: be even more strict by requring the model id to be present in the config to proceed?
         if model_config is None:
             error_msg = (
@@ -2087,9 +2071,9 @@ class Pipe:
 
         raise ValueError("Exhausted execution options without result.")
 
-    # region 2. Helper methods inside the Pipe class
+    # region 1. Helper methods inside the Pipe class
 
-    # region 2.1 Client initialization
+    # region 1.1 Client initialization
     @staticmethod
     @cache
     def _get_or_create_genai_client(
@@ -2180,9 +2164,9 @@ class Pipe:
         ]
         return [getattr(source_valves, attr, None) for attr in ATTRS]
 
-    # endregion 2.1 Client initialization
+    # endregion 1.1 Client initialization
 
-    # region 2.2 Model retrival from Google API
+    # region 1.2 Model retrival from Google API
     @cached()  # aiocache.cached for async method
     async def _get_genai_models(
         self,
@@ -2524,9 +2508,9 @@ class Pipe:
 
         return False
 
-    # endregion 2.2 Model retrival from Google API
+    # endregion 1.2 Model retrival from Google API
 
-    # region 2.3 GenerateContentConfig assembly
+    # region 1.3 GenerateContentConfig assembly
 
     async def _build_gen_content_config(
         self,
@@ -2761,9 +2745,9 @@ class Pipe:
 
         return gen_content_conf
 
-    # endregion 2.3 GenerateContentConfig assembly
+    # endregion 1.3 GenerateContentConfig assembly
 
-    # region 2.4 Model response processing
+    # region 1.4 Model response processing
 
     async def _aggregate_to_dict(
         self,
@@ -3408,9 +3392,9 @@ class Pipe:
         else:
             return None
 
-    # endregion 2.4 Model response processing
+    # endregion 1.4 Model response processing
 
-    # region 2.5 Post-processing
+    # region 1.5 Post-processing
     async def _do_post_processing(
         self,
         model_response: types.GenerateContentResponse | None,
@@ -3740,240 +3724,9 @@ class Pipe:
 
         return usage_payload
 
-    # endregion 2.5 Post-processing
+    # endregion 1.5 Post-processing
 
-    # region 2.6 Logging
-    # TODO: Move to a separate plugin that does not have any Open WebUI funcitonlity and is only imported by this plugin.
-
-    def _is_flat_dict(self, data: Any) -> bool:
-        """
-        Checks if a dictionary contains only non-dict/non-list values (is one level deep).
-        """
-        if not isinstance(data, dict):
-            return False
-        return not any(isinstance(value, (dict, list)) for value in data.values())
-
-    def _truncate_long_strings(
-        self, data: Any, max_len: int, truncation_marker: str, truncation_enabled: bool
-    ) -> Any:
-        """
-        Recursively traverses a data structure (dicts, lists) and truncates
-        long string values. Creates copies to avoid modifying original data.
-
-        Args:
-            data: The data structure (dict, list, str, int, float, bool, None) to process.
-            max_len: The maximum allowed length for string values.
-            truncation_marker: The string to append to truncated values.
-            truncation_enabled: Whether truncation is enabled.
-
-        Returns:
-            A potentially new data structure with long strings truncated.
-        """
-        if not truncation_enabled or max_len <= len(truncation_marker):
-            # If truncation is disabled or max_len is too small, return original
-            # Make a copy only if it's a mutable type we might otherwise modify
-            if isinstance(data, (dict, list)):
-                return copy.deepcopy(data)  # Ensure deep copy for nested structures
-            return data  # Primitives are immutable
-
-        if isinstance(data, str):
-            if len(data) > max_len:
-                return data[: max_len - len(truncation_marker)] + truncation_marker
-            return data  # Return original string if not truncated
-        elif isinstance(data, dict):
-            # Process dictionary items, creating a new dict
-            return {
-                k: self._truncate_long_strings(
-                    v, max_len, truncation_marker, truncation_enabled
-                )
-                for k, v in data.items()
-            }
-        elif isinstance(data, list):
-            # Process list items, creating a new list
-            return [
-                self._truncate_long_strings(
-                    item, max_len, truncation_marker, truncation_enabled
-                )
-                for item in data
-            ]
-        else:
-            # Return non-string, non-container types as is (they are immutable)
-            return data
-
-    def plugin_stdout_format(self, record: "Record") -> str:
-        """
-        Custom format function for the plugin's logs.
-        Serializes and truncates data passed under the 'payload' key in extra.
-        """
-
-        # Configuration Keys
-        LOG_OPTIONS_PREFIX = "_log_"
-        TRUNCATION_ENABLED_KEY = f"{LOG_OPTIONS_PREFIX}truncation_enabled"
-        MAX_LENGTH_KEY = f"{LOG_OPTIONS_PREFIX}max_length"
-        TRUNCATION_MARKER_KEY = f"{LOG_OPTIONS_PREFIX}truncation_marker"
-        DATA_KEY = "payload"
-
-        original_extra = record["extra"]
-        # Extract the data intended for serialization using the chosen key
-        data_to_process = original_extra.get(DATA_KEY)
-
-        serialized_data_json = ""
-        if data_to_process is not None:
-            try:
-                serializable_data = pydantic_core.to_jsonable_python(
-                    data_to_process, serialize_unknown=True, exclude_none=True
-                )
-
-                # Determine truncation settings
-                truncation_enabled = original_extra.get(TRUNCATION_ENABLED_KEY, True)
-                max_length = original_extra.get(MAX_LENGTH_KEY, 256)
-                truncation_marker = original_extra.get(TRUNCATION_MARKER_KEY, "[...]")
-
-                # If max_length was explicitly provided, force truncation enabled
-                if MAX_LENGTH_KEY in original_extra:
-                    truncation_enabled = True
-
-                # Truncate long strings
-                truncated_data = self._truncate_long_strings(
-                    serializable_data,
-                    max_length,
-                    truncation_marker,
-                    truncation_enabled,
-                )
-
-                # Serialize the (potentially truncated) data
-                if self._is_flat_dict(truncated_data) and not isinstance(
-                    truncated_data, list
-                ):
-                    json_string = json.dumps(
-                        truncated_data, separators=(",", ":"), default=str
-                    )
-                    # Add a simple prefix if it's compact
-                    serialized_data_json = " - " + json_string
-                else:
-                    json_string = json.dumps(truncated_data, indent=2, default=str)
-                    # Prepend with newline for readability
-                    serialized_data_json = "\n" + json_string
-
-            except (TypeError, ValueError) as e:  # Catch specific serialization errors
-                serialized_data_json = f" - {{Serialization Error: {e}}}"
-            except (
-                Exception
-            ) as e:  # Catch any other unexpected errors during processing
-                serialized_data_json = f" - {{Processing Error: {e}}}"
-
-        # Add the final JSON string (or error message) back into the record
-        record["extra"]["_plugin_serialized_data"] = serialized_data_json
-
-        # Base template
-        base_template = (
-            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-            "<level>{level: <8}</level> | "
-            "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
-            "<level>{message}</level>"
-        )
-
-        # Append the serialized data
-        base_template += "{extra[_plugin_serialized_data]}"
-        # Append the exception part
-        base_template += "\n{exception}"
-        # Return the format string template
-        return base_template.rstrip()
-
-    @cache
-    def _add_log_handler(self, log_level: str):
-        """
-        Adds or updates the loguru handler specifically for this plugin.
-        Includes logic for serializing and truncating extra data.
-        The handler is added only if the log_level has changed since the last call.
-        """
-
-        def plugin_filter(record: "Record"):
-            """Filter function to only allow logs from this plugin (based on module name)."""
-            return record["name"] == __name__
-
-        # Get the desired level name and number
-        desired_level_name = log_level
-        try:
-            # Use the public API to get level details
-            desired_level_info = log.level(desired_level_name)
-            desired_level_no = desired_level_info.no
-        except ValueError:
-            log.error(
-                f"Invalid LOG_LEVEL '{desired_level_name}' configured for plugin {__name__}. Cannot add/update handler."
-            )
-            return  # Stop processing if the level is invalid
-
-        # Access the internal state of the log
-        handlers: dict[int, "Handler"] = log._core.handlers  # type: ignore
-        handler_id_to_remove = None
-        found_correct_handler = False
-
-        for handler_id, handler in handlers.items():
-            existing_filter = handler._filter  # Access internal attribute
-
-            # Check if the filter matches our plugin_filter
-            # Comparing function objects directly can be fragile if they are recreated.
-            # Comparing by name and module is more robust for functions defined at module level.
-            is_our_filter = (
-                existing_filter is not None  # Make sure a filter is set
-                and hasattr(existing_filter, "__name__")
-                and existing_filter.__name__ == plugin_filter.__name__
-                and hasattr(existing_filter, "__module__")
-                and existing_filter.__module__ == plugin_filter.__module__
-            )
-
-            if is_our_filter:
-                existing_level_no = handler.levelno
-                log.trace(
-                    f"Found existing handler {handler_id} for {__name__} with level number {existing_level_no}."
-                )
-
-                # Check if the level matches the desired level
-                if existing_level_no == desired_level_no:
-                    log.debug(
-                        f"Handler {handler_id} for {__name__} already exists with the correct level '{desired_level_name}'."
-                    )
-                    found_correct_handler = True
-                    break  # Found the correct handler, no action needed
-                else:
-                    # Found our handler, but the level is wrong. Mark for removal.
-                    log.info(
-                        f"Handler {handler_id} for {__name__} found, but log level differs "
-                        f"(existing: {existing_level_no}, desired: {desired_level_no}). "
-                        f"Removing it to update."
-                    )
-                    handler_id_to_remove = handler_id
-                    break  # Found the handler to replace, stop searching
-
-        # Remove the old handler if marked for removal
-        if handler_id_to_remove is not None:
-            try:
-                log.remove(handler_id_to_remove)
-                log.debug(f"Removed handler {handler_id_to_remove} for {__name__}.")
-            except ValueError:
-                # This might happen if the handler was somehow removed between the check and now
-                log.warning(
-                    f"Could not remove handler {handler_id_to_remove} for {__name__}. It might have already been removed."
-                )
-                # If removal failed but we intended to remove, we should still proceed to add
-                # unless found_correct_handler is somehow True (which it shouldn't be if handler_id_to_remove was set).
-
-        # Add a new handler if no correct one was found OR if we just removed an incorrect one
-        if not found_correct_handler:
-            log.add(
-                sys.stdout,
-                level=desired_level_name,
-                format=self.plugin_stdout_format,
-                filter=plugin_filter,
-            )
-            log.debug(
-                f"Added new handler to loguru for {__name__} with level {desired_level_name}."
-            )
-
-    # endregion 2.6 Logging
-
-    # region 2.7 Utility helpers
+    # region 1.6 Utility helpers
 
     async def _determine_execution_order(
         self,
@@ -4329,6 +4082,6 @@ class Pipe:
                     f"Could not parse companion version string: '{companion_version}'. Version check skipped."
                 )
 
-    # endregion 2.7 Utility helpers
+    # endregion 1.6 Utility helpers
 
-    # endregion 2. Helper methods inside the Pipe class
+    # endregion 1. Helper methods inside the Pipe class

--- a/plugins/pipes/venice_manifold.py
+++ b/plugins/pipes/venice_manifold.py
@@ -17,13 +17,10 @@ version: 0.11.0
 # TODO: Negative prompts
 # TODO: Upscaling
 
-import copy
 import inspect
 import io
-import json
 import mimetypes
 import os
-import sys
 import time
 import asyncio
 import uuid
@@ -32,19 +29,15 @@ import base64
 from collections.abc import Awaitable, Callable
 from typing import (
     Any,
-    Literal,
     TYPE_CHECKING,
 )
 from pydantic import BaseModel, Field
 from fastapi import Request
-import pydantic_core
 from open_webui.models.files import Files, FileForm
 from open_webui.storage.provider import Storage
 from loguru import logger
 
 if TYPE_CHECKING:
-    from loguru import Record
-    from loguru._handler import Handler  # type: ignore
     from utils.manifold_types import *  # My personal types in a separate file for more robustness.
 
 
@@ -62,7 +55,6 @@ _SHARED_VALVE_DESCS = {
 _ADMIN_VALVE_DESCS = {
     "VENICE_API_TOKEN": "Venice.ai API Token.",
     "CACHE_MODELS": "Whether to request and cache available models only on initial load.",
-    "LOG_LEVEL": "Select logging verbosity level. View logs using `docker logs -f open-webui`.",
     "USE_FILES_API": "Save generated image files using Open WebUI's file storage API.",
 }
 
@@ -106,14 +98,6 @@ class Pipe:
             default=True,
             description=_format_valve_desc(
                 _ADMIN_VALVE_DESCS["CACHE_MODELS"], default=True
-            ),
-        )
-        LOG_LEVEL: Literal[
-            "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"
-        ] = Field(
-            default="INFO",
-            description=_format_valve_desc(
-                _ADMIN_VALVE_DESCS["LOG_LEVEL"], default="INFO"
             ),
         )
         USE_FILES_API: bool = Field(
@@ -174,23 +158,10 @@ class Pipe:
 
     def __init__(self):
         self.valves = self.Valves()
-        self.log_level = self.valves.LOG_LEVEL
-        self._add_log_handler()
-
         self.models: list["ModelData"] = []
-
         log.success("Function has been initialized.")
-        log.trace("Full self object:", payload=self.__dict__)
 
     async def pipes(self) -> list["ModelData"]:
-        if self.log_level != self.valves.LOG_LEVEL:
-            log.info(
-                f"Detected log level change: {self.log_level=} and {self.valves.LOG_LEVEL=}. "
-                "Running the logging setup again."
-            )
-            self.log_level = self.valves.LOG_LEVEL
-            self._add_log_handler()
-
         if (
             self.models
             and self.valves.CACHE_MODELS
@@ -501,233 +472,5 @@ class Pipe:
         await self.__event_emitter__(error)
 
     # endregion 1.3 Event emissions
-
-    # region 1.4 Logging
-    def _is_flat_dict(self, data: Any) -> bool:
-        """
-        Checks if a dictionary contains only non-dict/non-list values (is one level deep).
-        """
-        if not isinstance(data, dict):
-            return False
-        return not any(isinstance(value, (dict, list)) for value in data.values())
-
-    def _truncate_long_strings(
-        self, data: Any, max_len: int, truncation_marker: str, truncation_enabled: bool
-    ) -> Any:
-        """
-        Recursively traverses a data structure (dicts, lists) and truncates
-        long string values. Creates copies to avoid modifying original data.
-
-        Args:
-            data: The data structure (dict, list, str, int, float, bool, None) to process.
-            max_len: The maximum allowed length for string values.
-            truncation_marker: The string to append to truncated values.
-            truncation_enabled: Whether truncation is enabled.
-
-        Returns:
-            A potentially new data structure with long strings truncated.
-        """
-        if not truncation_enabled or max_len <= len(truncation_marker):
-            # If truncation is disabled or max_len is too small, return original
-            # Make a copy only if it's a mutable type we might otherwise modify
-            if isinstance(data, (dict, list)):
-                return copy.deepcopy(data)  # Ensure deep copy for nested structures
-            return data  # Primitives are immutable
-
-        if isinstance(data, str):
-            if len(data) > max_len:
-                return data[: max_len - len(truncation_marker)] + truncation_marker
-            return data  # Return original string if not truncated
-        elif isinstance(data, dict):
-            # Process dictionary items, creating a new dict
-            return {
-                k: self._truncate_long_strings(
-                    v, max_len, truncation_marker, truncation_enabled
-                )
-                for k, v in data.items()
-            }
-        elif isinstance(data, list):
-            # Process list items, creating a new list
-            return [
-                self._truncate_long_strings(
-                    item, max_len, truncation_marker, truncation_enabled
-                )
-                for item in data
-            ]
-        else:
-            # Return non-string, non-container types as is (they are immutable)
-            return data
-
-    def plugin_stdout_format(self, record: "Record") -> str:
-        """
-        Custom format function for the plugin's logs.
-        Serializes and truncates data passed under the 'payload' key in extra.
-        """
-
-        # Configuration Keys
-        LOG_OPTIONS_PREFIX = "_log_"
-        TRUNCATION_ENABLED_KEY = f"{LOG_OPTIONS_PREFIX}truncation_enabled"
-        MAX_LENGTH_KEY = f"{LOG_OPTIONS_PREFIX}max_length"
-        TRUNCATION_MARKER_KEY = f"{LOG_OPTIONS_PREFIX}truncation_marker"
-        DATA_KEY = "payload"
-
-        original_extra = record["extra"]
-        # Extract the data intended for serialization using the chosen key
-        data_to_process = original_extra.get(DATA_KEY)
-
-        serialized_data_json = ""
-        if data_to_process is not None:
-            try:
-                serializable_data = pydantic_core.to_jsonable_python(
-                    data_to_process, serialize_unknown=True
-                )
-
-                # Determine truncation settings
-                truncation_enabled = original_extra.get(TRUNCATION_ENABLED_KEY, True)
-                max_length = original_extra.get(MAX_LENGTH_KEY, 256)
-                truncation_marker = original_extra.get(TRUNCATION_MARKER_KEY, "[...]")
-
-                # If max_length was explicitly provided, force truncation enabled
-                if MAX_LENGTH_KEY in original_extra:
-                    truncation_enabled = True
-
-                # Truncate long strings
-                truncated_data = self._truncate_long_strings(
-                    serializable_data,
-                    max_length,
-                    truncation_marker,
-                    truncation_enabled,
-                )
-
-                # Serialize the (potentially truncated) data
-                if self._is_flat_dict(truncated_data) and not isinstance(
-                    truncated_data, list
-                ):
-                    json_string = json.dumps(
-                        truncated_data, separators=(",", ":"), default=str
-                    )
-                    # Add a simple prefix if it's compact
-                    serialized_data_json = " - " + json_string
-                else:
-                    json_string = json.dumps(truncated_data, indent=2, default=str)
-                    # Prepend with newline for readability
-                    serialized_data_json = "\n" + json_string
-
-            except (TypeError, ValueError) as e:  # Catch specific serialization errors
-                serialized_data_json = f" - {{Serialization Error: {e}}}"
-            except (
-                Exception
-            ) as e:  # Catch any other unexpected errors during processing
-                serialized_data_json = f" - {{Processing Error: {e}}}"
-
-        # Add the final JSON string (or error message) back into the record
-        record["extra"]["_plugin_serialized_data"] = serialized_data_json
-
-        # Base template
-        base_template = (
-            "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-            "<level>{level: <8}</level> | "
-            "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
-            "<level>{message}</level>"
-        )
-
-        # Append the serialized data
-        base_template += "{extra[_plugin_serialized_data]}"
-        # Append the exception part
-        base_template += "\n{exception}"
-        # Return the format string template
-        return base_template.rstrip()
-
-    def _add_log_handler(self):
-        """
-        Adds or updates the loguru handler specifically for this plugin.
-        Includes logic for serializing and truncating extra data.
-        """
-
-        def plugin_filter(record: "Record"):
-            """Filter function to only allow logs from this plugin (based on module name)."""
-            return record["name"] == __name__
-
-        # Get the desired level name and number
-        desired_level_name = self.valves.LOG_LEVEL
-        try:
-            # Use the public API to get level details
-            desired_level_info = log.level(desired_level_name)
-            desired_level_no = desired_level_info.no
-        except ValueError:
-            log.error(
-                f"Invalid LOG_LEVEL '{desired_level_name}' configured for plugin {__name__}. Cannot add/update handler."
-            )
-            return  # Stop processing if the level is invalid
-
-        # Access the internal state of the log
-        handlers: dict[int, "Handler"] = log._core.handlers  # type: ignore
-        handler_id_to_remove = None
-        found_correct_handler = False
-
-        for handler_id, handler in handlers.items():
-            existing_filter = handler._filter  # Access internal attribute
-
-            # Check if the filter matches our plugin_filter
-            # Comparing function objects directly can be fragile if they are recreated.
-            # Comparing by name and module is more robust for functions defined at module level.
-            is_our_filter = (
-                existing_filter is not None  # Make sure a filter is set
-                and hasattr(existing_filter, "__name__")
-                and existing_filter.__name__ == plugin_filter.__name__
-                and hasattr(existing_filter, "__module__")
-                and existing_filter.__module__ == plugin_filter.__module__
-            )
-
-            if is_our_filter:
-                existing_level_no = handler.levelno
-                log.trace(
-                    f"Found existing handler {handler_id} for {__name__} with level number {existing_level_no}."
-                )
-
-                # Check if the level matches the desired level
-                if existing_level_no == desired_level_no:
-                    log.debug(
-                        f"Handler {handler_id} for {__name__} already exists with the correct level '{desired_level_name}'."
-                    )
-                    found_correct_handler = True
-                    break  # Found the correct handler, no action needed
-                else:
-                    # Found our handler, but the level is wrong. Mark for removal.
-                    log.info(
-                        f"Handler {handler_id} for {__name__} found, but log level differs "
-                        f"(existing: {existing_level_no}, desired: {desired_level_no}). "
-                        f"Removing it to update."
-                    )
-                    handler_id_to_remove = handler_id
-                    break  # Found the handler to replace, stop searching
-
-        # Remove the old handler if marked for removal
-        if handler_id_to_remove is not None:
-            try:
-                log.remove(handler_id_to_remove)
-                log.debug(f"Removed handler {handler_id_to_remove} for {__name__}.")
-            except ValueError:
-                # This might happen if the handler was somehow removed between the check and now
-                log.warning(
-                    f"Could not remove handler {handler_id_to_remove} for {__name__}. It might have already been removed."
-                )
-                # If removal failed but we intended to remove, we should still proceed to add
-                # unless found_correct_handler is somehow True (which it shouldn't be if handler_id_to_remove was set).
-
-        # Add a new handler if no correct one was found OR if we just removed an incorrect one
-        if not found_correct_handler:
-            self.log_level = desired_level_name
-            log.add(
-                sys.stdout,
-                level=desired_level_name,
-                format=self.plugin_stdout_format,
-                filter=plugin_filter,
-            )
-            log.debug(
-                f"Added new handler to loguru for {__name__} with level {desired_level_name}."
-            )
-
-    # endregion 1.4 Logging
 
     # endregion 1. Helper methods inside the Pipe class

--- a/tests/test_gemini_manifold.py
+++ b/tests/test_gemini_manifold.py
@@ -85,8 +85,6 @@ def mock_pipe_valves_data():
         "SHOW_THINKING_SUMMARY": True,
         "USE_FILES_API": True,
         "THINKING_MODEL_PATTERN": r"gemini-2.5",
-        "LOG_LEVEL": "INFO",
-        "ENABLE_URL_CONTEXT_TOOL": False,
     }
 
 
@@ -101,11 +99,7 @@ async def pipe_instance_fixture(mock_pipe_valves_data):
     with patch(
         "plugins.pipes.gemini_manifold.genai.Client",
         return_value=mock_gemini_client_actual_instance,
-    ) as MockedGenAIClientConstructor, patch.object(
-        Pipe, "_add_log_handler", MagicMock()
-    ), patch(
-        "sys.stdout", MagicMock()
-    ):
+    ) as MockedGenAIClientConstructor:
         pipe = Pipe()
         # Initialize with base data from mock_pipe_valves_data
         pipe.valves = Pipe.Valves(**mock_pipe_valves_data)
@@ -133,11 +127,7 @@ def test_pipe_initialization_with_api_key_prefers_free(mock_pipe_valves_data):
     with patch(
         "plugins.pipes.gemini_manifold.genai.Client",
         return_value=mock_gemini_client_instance,
-    ) as MockedGenAIClientConstructor, patch.object(
-        Pipe, "_add_log_handler", MagicMock()
-    ), patch(
-        "sys.stdout", MagicMock()
-    ):
+    ) as MockedGenAIClientConstructor:
         try:
             pipe_instance = Pipe()
             pipe_instance.valves = Pipe.Valves(**mock_pipe_valves_data)
@@ -170,11 +160,7 @@ def test_get_user_client_no_auth_provided_raises_error(mock_pipe_valves_data):
 
     with patch(
         "plugins.pipes.gemini_manifold.genai.Client"
-    ) as MockedGenAIClientConstructor, patch.object(
-        Pipe, "_add_log_handler", MagicMock()
-    ), patch(
-        "sys.stdout", MagicMock()
-    ):
+    ) as MockedGenAIClientConstructor:
         pipe_instance = Pipe()
         pipe_instance.valves = Pipe.Valves(**mock_pipe_valves_data)
 


### PR DESCRIPTION
Moves the logic that allows for per-plugin log level control and truncation into it's own optional `Pipe` plugin.